### PR TITLE
Removed parameter that no longer exists for.

### DIFF
--- a/includes/highlighting.inc
+++ b/includes/highlighting.inc
@@ -20,7 +20,7 @@ function islandora_paged_content_perform_solr_highlighting_query($query, $params
   $sequence_field = variable_get('islandora_paged_content_sequence_number_field', 'RELS_EXT_isSequenceNumber_literal_ms');
   $params['fl'] = "PID,{$sequence_field}";
   $solr_results = islandora_ocr_highlighted_solr_search($query, 0, -1, $params);
-  $results = islandora_ocr_map_highlighted_solr_results_to_bounding_boxes($solr_results, $params);
+  $results = islandora_ocr_map_highlighted_solr_results_to_bounding_boxes($solr_results);
   foreach ($solr_results['response']['docs'] as $doc) {
     $id = $doc['PID'];
     if (isset($doc[$sequence_field])) {


### PR DESCRIPTION
OnTime: #1332 HOCR Bounding Box "Deduplication"

Removed unused $solr_params option for the function:

islandora_ocr_map_highlighted_solr_results_to_bounding_boxes().

Related to https://github.com/Islandora/islandora_ocr/pull/18
