### PR TITLE
The url set here needs to be externally accessible.

### DIFF
--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -52,7 +52,7 @@ function islandora_paged_content_admin_settings_form(array $form, array &$form_s
       '#prefix' => '<div id="djatoka-path-wrapper">',
       '#suffix' => '</div>',
       '#title' => t('djatoka URL'),
-      '#description' => filter_xss(t('URL to the djatoka instance.<br/>!msg', array('!msg' => $djatoka_availible_message))),
+      '#description' => filter_xss(t('<strong>Externally accessible</strong> URL to the djatoka instance.<br/>!msg', array('!msg' => $djatoka_availible_message))),
       '#default_value' => $djatoka_url,
       '#ajax' => array(
         'callback' => 'islandora_paged_content_admin_settings_form_djatoka_ajax_callback',


### PR DESCRIPTION
See commit message. The way I am understanding this, is that the users's browser is using the variable set here to access the images in the Internet Archive viewer. If you set localhost, no images will load, unless, you're running Djatoka on your local machine :smirk:.

Completely open to different verbiage used here so the repo admins know what's up here.
