### PR TITLE
Windows-compatibility: Thumbnail generation / Undefined variable (Islandora Paged Content)

### DIFF
--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -124,7 +124,7 @@ function islandora_paged_content_admin_settings_form_executable_available_messag
  *   The element to render as part the ajax callback.
  */
 function islandora_paged_content_admin_settings_form_gs_ajax_callback(array $form, array $form_state) {
-  return $form['local_derivative_settings']['pdf_derivative_settings']['islandora_book_gs'];
+  return $form['local_derivative_settings']['pdf_derivative_settings']['islandora_paged_content_gs'];
 }
 
 /**

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -346,7 +346,7 @@ function islandora_paged_content_can_create_pdf() {
  *   TRUE if it is possible, FALSE otherwise.
  */
 function islandora_paged_content_can_combine_pdf() {
-  // slangerx: Variable name was previously 'islandora_book_gs', which doesn't exist. Typo?
+  // slangerx: Variable name was 'islandora_book_gs', which doesn't exist.
   $gs = variable_get('islandora_paged_content_gs', '/usr/bin/gs');
   return is_executable($gs);
 }
@@ -383,7 +383,7 @@ function islandora_paged_content_pdf_append($file, array $files) {
  *   TRUE on success, FALSE otherwise.
  */
 function islandora_paged_content_pdf_combine(array $files, $out) {
-  // slangerx: Variable name was previously 'islandora_book_gs', which doesn't exist. Typo?
+  // slangerx: Variable name was 'islandora_book_gs', which doesn't exist.
   $gs = variable_get('islandora_paged_content_gs', '/usr/bin/gs');
   $files = implode(' ', $files);
   $command = "{$gs} -dBATCH -dNOPAUSE -q -sDEVICE=pdfwrite -sOutputFile={$out} {$files}";
@@ -558,7 +558,7 @@ function islandora_paged_content_update_paged_content_thumbnail(AbstractObject $
   $mime_detector = new MimeDetect();
   $ext = $mime_detector->getExtension($page['TN']->mimeType);
   // slangerx: For some reason, complex syntax {$...} sometimes doesn't get
-  // processed, resulting in error messages like: "The file {$page->id}_TN.{$ext}
+  // processed, causing error messages like: "The file {$page->id}_TN.{$ext}
   // cannot be found." Concatenating the variables seemed to fix this problem.
   $file = drupal_realpath('temporary://' . str_replace(':', '-', $page->id) . '_TN.' . $ext);
   $page['TN']->getContent($file);

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -557,7 +557,7 @@ function islandora_paged_content_update_paged_content_thumbnail(AbstractObject $
   $page = islandora_object_load($page['pid']);
   $mime_detector = new MimeDetect();
   $ext = $mime_detector->getExtension($page['TN']->mimeType);
-  // slangerx: Concatenate the variables (rather than using complex syntax).
+  // slangerx: Concatenate the path (rather than using complex syntax).
   $file = drupal_realpath('temporary://' . str_replace(':', '-', $page->id) . '_TN.' . $ext);
   $page['TN']->getContent($file);
   $ret = islandora_paged_content_update_datastream($object,

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -346,7 +346,8 @@ function islandora_paged_content_can_create_pdf() {
  *   TRUE if it is possible, FALSE otherwise.
  */
 function islandora_paged_content_can_combine_pdf() {
-  $gs = variable_get('islandora_book_gs', '/usr/bin/gs');
+  // slangerx: Variable name was previously 'islandora_book_gs', which doesn't exist. Typo?
+  $gs = variable_get('islandora_paged_content_gs', '/usr/bin/gs');
   return is_executable($gs);
 }
 
@@ -382,7 +383,8 @@ function islandora_paged_content_pdf_append($file, array $files) {
  *   TRUE on success, FALSE otherwise.
  */
 function islandora_paged_content_pdf_combine(array $files, $out) {
-  $gs = variable_get('islandora_book_gs', '/usr/bin/gs');
+  // slangerx: Variable name was previously 'islandora_book_gs', which doesn't exist. Typo?
+  $gs = variable_get('islandora_paged_content_gs', '/usr/bin/gs');
   $files = implode(' ', $files);
   $command = "{$gs} -dBATCH -dNOPAUSE -q -sDEVICE=pdfwrite -sOutputFile={$out} {$files}";
   $output = array(); $ret = 0;
@@ -555,7 +557,10 @@ function islandora_paged_content_update_paged_content_thumbnail(AbstractObject $
   $page = islandora_object_load($page['pid']);
   $mime_detector = new MimeDetect();
   $ext = $mime_detector->getExtension($page['TN']->mimeType);
-  $file = drupal_realpath("temporary://{$page->id}_TN.{$ext}");
+  // slangerx: For some reason, complex syntax {$...} sometimes doesn't get
+  // processed, resulting in error messages like: "The file {$page->id}_TN.{$ext}
+  // cannot be found." Concatenating the variables seemed to fix this problem.
+  $file = drupal_realpath('temporary://' . str_replace(':', '-', $page->id) . '_TN.' . $ext);
   $page['TN']->getContent($file);
   $ret = islandora_paged_content_update_datastream($object,
     $file,

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -557,9 +557,7 @@ function islandora_paged_content_update_paged_content_thumbnail(AbstractObject $
   $page = islandora_object_load($page['pid']);
   $mime_detector = new MimeDetect();
   $ext = $mime_detector->getExtension($page['TN']->mimeType);
-  // slangerx: For some reason, complex syntax {$...} sometimes doesn't get
-  // processed, causing error messages like: "The file {$page->id}_TN.{$ext}
-  // cannot be found." Concatenating the variables seemed to fix this problem.
+  // slangerx: Concatenate the variables (rather than using complex syntax).
   $file = drupal_realpath('temporary://' . str_replace(':', '-', $page->id) . '_TN.' . $ext);
   $page['TN']->getContent($file);
   $ret = islandora_paged_content_update_datastream($object,

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -346,7 +346,6 @@ function islandora_paged_content_can_create_pdf() {
  *   TRUE if it is possible, FALSE otherwise.
  */
 function islandora_paged_content_can_combine_pdf() {
-  // slangerx: Variable name was 'islandora_book_gs', which doesn't exist.
   $gs = variable_get('islandora_paged_content_gs', '/usr/bin/gs');
   return is_executable($gs);
 }
@@ -383,7 +382,6 @@ function islandora_paged_content_pdf_append($file, array $files) {
  *   TRUE on success, FALSE otherwise.
  */
 function islandora_paged_content_pdf_combine(array $files, $out) {
-  // slangerx: Variable name was 'islandora_book_gs', which doesn't exist.
   $gs = variable_get('islandora_paged_content_gs', '/usr/bin/gs');
   $files = implode(' ', $files);
   $command = "{$gs} -dBATCH -dNOPAUSE -q -sDEVICE=pdfwrite -sOutputFile={$out} {$files}";
@@ -549,6 +547,7 @@ function islandora_paged_content_can_update_paged_content_thumbnail(AbstractObje
  *   TRUE on success, FALSE otherwise.
  */
 function islandora_paged_content_update_paged_content_thumbnail(AbstractObject $object) {
+  module_load_include('inc', 'islandora', 'includes/utilities');
   if (!islandora_paged_content_can_update_paged_content_thumbnail($object)) {
     return FALSE;
   }
@@ -557,8 +556,11 @@ function islandora_paged_content_update_paged_content_thumbnail(AbstractObject $
   $page = islandora_object_load($page['pid']);
   $mime_detector = new MimeDetect();
   $ext = $mime_detector->getExtension($page['TN']->mimeType);
-  // slangerx: Concatenate the path, rather than using complex syntax.
-  $file = drupal_realpath('temporary://' . str_replace(':', '-', $page->id) . '_TN.' . $ext);
+  // Windows will likely store temp data in a temp directory
+  // rather than in memory. Since the colon is forbidden in
+  // filenames, replace it with an underscore instead.
+  $thumbnail_id = ((islandora_deployed_on_windows()) ? str_replace(':', '_', $page->id) : $page->id);
+  $file = drupal_realpath("temporary://{$thumbnail_id}_TN.{$ext}");
   $page['TN']->getContent($file);
   $ret = islandora_paged_content_update_datastream($object,
     $file,

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -557,7 +557,7 @@ function islandora_paged_content_update_paged_content_thumbnail(AbstractObject $
   $page = islandora_object_load($page['pid']);
   $mime_detector = new MimeDetect();
   $ext = $mime_detector->getExtension($page['TN']->mimeType);
-  // slangerx: Concatenate the path (rather than using complex syntax).
+  // slangerx: Concatenate the path, rather than using complex syntax.
   $file = drupal_realpath('temporary://' . str_replace(':', '-', $page->id) . '_TN.' . $ext);
   $page['TN']->getContent($file);
   $ret = islandora_paged_content_update_datastream($object,


### PR DESCRIPTION
Some Windows-incompatibilities have crept into the Islandora codebase ([additional background can be found here](https://groups.google.com/d/msg/islandora/0MAhLDjbago/9knbOynlyIcJ)).
- **Undefined variable:** I believe I've discovered references to an undefined variable, perhaps left over from a previous version of this module. More than once, the module tries to call a variable named "islandora_book_gs," but that doesn't seem to ever get defined by this module or any other. Perhaps this wasn't noticed before because `variable_get` uses a default value ("/usr/bin/gs") when that variable can't be found: a Linux-friendly path to Ghostscript that obviously does not work on a Windows machine. This patch changes the variable name to "islandora_paged_content_gs" instead, which _does_ get defined by the module.
- **Thumbnail name:** Windows will sometimes write temporary data to a temp directory rather than to straight memory (this was a [necessary change to the Tuque library](https://github.com/Islandora/tuque/pull/83)). As a result, the code that generates the first-page thumbnail needs to be updated. Specifically, the colon in the object ID needs to be replaced with an underscore in the filename, since the [colon is a forbidden character in Windows paths](http://msdn.microsoft.com/en-us/library/windows/desktop/aa365247%28v=vs.85%29.aspx#naming_conventions). Using it results in errors such as: 
  `Warning: filesize(): stat failed for <PATH TO TEMP DIRECTORY>/islandora:XX_TN.jpg in CurlConnection->putRequest()`
  `The file <PATH TO TEMP DIRECTORY>/islandora:XX_TN.jpg was not deleted, because it does not exist.`

_NOTE 1:_ The [Compound Solution Pack](https://github.com/Islandora/islandora_solution_pack_compound/pull/29) is experiencing the same problem.
_NOTE 2:_ The function _islandora_deployed_on_windows()_ is introduced here: https://github.com/Islandora/islandora/pull/450
