### PR TITLE
Let manuscripts / pages derive content as well.

### DIFF
--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -295,6 +295,8 @@ function islandora_paged_content_can_derive(AbstractObject $object, $dsid) {
     'islandora:pageCModel',
     'islandora:bookPageCModel',
     'islandora:newspaperPageCModel',
+    'islandora:manuscriptCModel',
+    'islandora:manuscriptPageCModel',
   );
   if (array_intersect($to_derive, $object->models)) {
     $check_function = array(


### PR DESCRIPTION
I'm not a big fan of this code, at some point after the summer rush it would be nice to refactor the paged content solution pack to have no awareness of what content models are using pages.
