### PR TITLE
Add xacml editor as dependency in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This module requires the following modules/libraries:
 
 * [Islandora](https://github.com/islandora/islandora)
 * [Tuque](https://github.com/islandora/tuque)
+* [Xacml Editor](https://github.com/Islandora/islandora_xacml_editor)
 
 ## Installation
 

--- a/islandora_paged_content.info
+++ b/islandora_paged_content.info
@@ -2,6 +2,7 @@ name = Islandora Paged Content
 description = Libraries for paged content in Islandora.
 dependencies[] = islandora
 dependencies[] = file
+dependencies[] = islandora_xacml_editor
 package = Islandora Solution Packs
 version = 7.x-dev
 core = 7.x


### PR DESCRIPTION
This code  https://github.com/Islandora/islandora_paged_content/blob/0c45c9e523fbb7df99d2c1754730b52b8a13c83b/includes/manage_pages.inc#L782 assumes that Xacml editor is present and in some cases (when using the zip importer for example) the ingest process will fail if XACML editor is not present. 
This PR adds XACML editor as a dependency in the repo docs. 

Note that this is true of 7.x-1.3 as well. Don't know what the policy is for updating those docs as well. 
