### PR TITLE
The options in this form did not match the options for text extractio…

### DIFF
--- a/includes/batch.inc
+++ b/includes/batch.inc
@@ -519,7 +519,7 @@ function islandora_paged_content_create_page_from_pdf_batch_operation(array $pag
     else {
       $context['messages'][] = t('Unable to extract a TIF for page @page', array('@page' => $page));
     }
-    if ($options['extract_text'] == 'pdftotext') {
+    if ($options['extract_text'] == 'extract') {
       $full_text = islandora_paged_content_extract_text_from_pdf($file->uri, $page);
       if ($full_text) {
         $context['results']['successful'][] = islandora_paged_content_update_datastream($object, $full_text, 'OCR', 'OCR', 'text/plain', 'M', FALSE);

--- a/includes/upload_pdf.form.inc
+++ b/includes/upload_pdf.form.inc
@@ -69,23 +69,23 @@ function islandora_paged_content_upload_pdf_form($form, &$form_state, $model) {
     '#collapsible' => FALSE,
   );
   $ocr_options = array(
-    'do_not_perform' => t('Do not extract text.'),
+    'none' => t('Do not extract text.'),
   );
   $states = array();
   $languages = array();
-  $default_value = 'do_not_perform';
+  $default_value = 'none';
   if (module_exists('islandora_ocr')) {
     module_load_include('inc', 'islandora_ocr', 'includes/utilities');
-    $ocr_options['tesseract'] = t('Perform OCR on the PDF.');
-    $states[] = array('value' => 'tesseract');
+    $ocr_options['ocr'] = t('Perform OCR on the PDF.');
+    $states[] = array('value' => 'ocr');
     $languages = islandora_ocr_get_enabled_tesseract_languages();
     // Don't need the no OCR option.
     unset($languages['no_ocr']);
   }
   if (islandora_paged_content_pdftotext_availability()) {
-    $ocr_options['pdftotext'] = t('Extract text from the PDF.');
-    $default_value = 'pdftotext';
-    $states[] = array('value' => 'pdftotext');
+    $ocr_options['extract'] = t('Extract text from the PDF.');
+    $default_value = 'extract';
+    $states[] = array('value' => 'extract');
     // Need to fallback if tesseract isn't available for future OCR.
     $languages = array(
       'eng' => t('English'),

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -1133,7 +1133,7 @@ function islandora_paged_content_add_relationships_to_child(AbstractObject $obje
   islandora_paged_content_set_relationship($rels_ext, ISLANDORA_RELS_EXT_URI, 'isSequenceNumber', $params['page_number'], TRUE);
   islandora_paged_content_set_relationship($rels_ext, ISLANDORA_RELS_EXT_URI, 'isPageNumber', $params['page_number'], TRUE);
   islandora_paged_content_set_relationship($rels_ext, ISLANDORA_RELS_EXT_URI, 'isSection', '1', TRUE);
-  if ($params['extract_text'] == 'do_not_perform') {
+  if ($params['extract_text'] == 'none') {
     $object->relationships->add(ISLANDORA_RELS_EXT_URI, 'generate_ocr', 'FALSE', RELS_TYPE_PLAIN_LITERAL);
   }
   else {


### PR DESCRIPTION
…n as provided by the batch, so this commit changes them such that they are the same. As when the batch was set up using an altered version of this form it did not know how to interpret the text extraction options. See https://github.com/discoverygarden/islandora_paged_content_pdf_batch
