### PR TITLE
Add ability to extract raw text when using pdftotext.

### DIFF
--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -88,6 +88,12 @@ function islandora_paged_content_admin_settings_form(array $form, array &$form_s
           'event' => 'change',
         ),
       ),
+      'islandora_paged_content_pdftotext_use_raw' => array(
+        '#type' => 'checkbox',
+        '#title' => t('Allow user to specify option of extracting raw text'),
+        '#description' => t('This will pass the -raw parameter off to pdftotext when extracting text. By default, pdftotext extracts text in natural reading order. In edge case documents, where PDF creation tools have made blocks in errorneous order, text extraction will yield unexpected results. As such, this parameter will pull out text in the order that the PDF creation tool wrote it (layout ignored). This is not a valid default option to have due to that PDF creation tools are not constrained to writing blocks in the order they appear and it is up to the PDF reader to render them correctly.'),
+        '#default_value' => variable_get('islandora_paged_content_pdftotext_use_raw', FALSE),
+      ),
     ),
     'islandora_paged_content_djatoka_url' => array(
       '#type' => 'textfield',

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -90,7 +90,7 @@ function islandora_paged_content_admin_settings_form(array $form, array &$form_s
       ),
       'islandora_paged_content_pdftotext_use_raw' => array(
         '#type' => 'checkbox',
-        '#title' => t('Allow user to specify option of extracting raw text'),
+        '#title' => t('Allow Extraction of Raw Text'),
         '#description' => t('This will pass the -raw parameter off to pdftotext when extracting text. By default, pdftotext extracts text in natural reading order. In edge case documents, where PDF creation tools have made blocks in errorneous order, text extraction will yield unexpected results. As such, this parameter will pull out text in the order that the PDF creation tool wrote it (layout ignored). This is not a valid default option to have due to that PDF creation tools are not constrained to writing blocks in the order they appear and it is up to the PDF reader to render them correctly.'),
         '#default_value' => variable_get('islandora_paged_content_pdftotext_use_raw', FALSE),
       ),

--- a/includes/upload_pdf.form.inc
+++ b/includes/upload_pdf.form.inc
@@ -105,20 +105,23 @@ function islandora_paged_content_upload_pdf_form($form, &$form_state, $model) {
     '#default_value' => $default_value,
     '#description' => t("Extracted text is used to aid in the discovery of this object when searching. If the uploaded PDF contains text and not just images of text, we recommend you try to extract it from the PDF. On the other hand if the uploaded PDF is composed of Images of text we and doesn't contain text we recommend you perform OCR."),
   );
-  $form['text_settings']['rawtext'] = array(
-    '#type' => 'radios',
-    '#title' => t('Use the raw text of the PDF'),
-    '#options' => array(
-      'yes' => t('Yes'),
-      'no' => t('No'),
-    ),
-    '#default_value' => 'no',
-    '#states' => array(
-      'visible' => array(
-        'input[name="extract_text"]' => array('value' => 'extract'),
+  if (variable_get('islandora_paged_content_pdftotext_use_raw', FALSE)) {
+    $form['text_settings']['rawtext'] = array(
+      '#type' => 'radios',
+      '#title' => t('Use the raw text of the PDF'),
+      '#description' => t('This will pass the -raw parameter off to pdftotext when extracting text. By default, pdftotext extracts text in natural reading order. In edge case documents, where PDF creation tools have made blocks in errorneous order, text extraction will yield unexpected results. As such, this parameter will pull out text in the order that the PDF creation tool wrote it (layout ignored). This is not a valid default option to have due to that PDF creation tools are not constrained to writing blocks in the order they appear and it is up to the PDF reader to render them correctly.'),
+      '#options' => array(
+        'yes' => t('Yes'),
+        'no' => t('No'),
       ),
-    ),
-  );
+      '#default_value' => 'no',
+      '#states' => array(
+        'visible' => array(
+          'input[name="extract_text"]' => array('value' => 'extract'),
+        ),
+      ),
+    );
+  }
   $form['text_settings']['language'] = array(
     '#type' => 'select',
     '#title' => t('Language'),
@@ -188,7 +191,12 @@ function islandora_paged_content_upload_pdf_form_submit($form, $form_state) {
       'extract_text',
       'model',
     ))) + array('pdf_file' => $file_obj, 'parent' => $object->id);
-    $options['rawtext'] = $form_state['values']['rawtext'] == 'yes' ? TRUE : FALSE;
+    if (variable_get('islandora_paged_content_pdftotext_use_raw', FALSE)) {
+      $options['rawtext'] = $form_state['values']['rawtext'] == 'yes' ? TRUE : FALSE;
+    }
+    else {
+      $options['rawtext'] = FALSE;
+    }
     $batch = islandora_paged_content_create_paged_content_from_pdf_batch($object, $pages, $options);
     batch_set($batch);
   }

--- a/includes/upload_pdf.form.inc
+++ b/includes/upload_pdf.form.inc
@@ -105,6 +105,20 @@ function islandora_paged_content_upload_pdf_form($form, &$form_state, $model) {
     '#default_value' => $default_value,
     '#description' => t("Extracted text is used to aid in the discovery of this object when searching. If the uploaded PDF contains text and not just images of text, we recommend you try to extract it from the PDF. On the other hand if the uploaded PDF is composed of Images of text we and doesn't contain text we recommend you perform OCR."),
   );
+  $form['text_settings']['rawtext'] = array(
+    '#type' => 'radios',
+    '#title' => t('Use the raw text of the PDF'),
+    '#options' => array(
+      'yes' => t('Yes'),
+      'no' => t('No'),
+    ),
+    '#default_value' => 'no',
+    '#states' => array(
+      'visible' => array(
+        'input[name="extract_text"]' => array('value' => 'extract'),
+      ),
+    ),
+  );
   $form['text_settings']['language'] = array(
     '#type' => 'select',
     '#title' => t('Language'),
@@ -174,6 +188,7 @@ function islandora_paged_content_upload_pdf_form_submit($form, $form_state) {
       'extract_text',
       'model',
     ))) + array('pdf_file' => $file_obj, 'parent' => $object->id);
+    $options['rawtext'] = $form_state['values']['rawtext'] == 'yes' ? TRUE : FALSE;
     $batch = islandora_paged_content_create_paged_content_from_pdf_batch($object, $pages, $options);
     batch_set($batch);
   }

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -908,15 +908,15 @@ function islandora_paged_content_pdfinfo_availability() {
  *   The page number to extract it will be used as the first and last page
  *   value. Note that pdftotext won't complain about using an offset greater
  *   than the number of allotted pages of a PDF.
- * @param bool $raw_text
- *   Whether to extract the raw text from the PDF or not.
  * @param bool $layout
  *   Whether we are retaining layout of the PDF or not.
+ * @param bool $raw_text
+ *   Whether to extract the raw text from the PDF or not.
  *
  * @return bool|string
  *   FALSE if it fails, the URI of the text file otherwise.
  */
-function islandora_paged_content_extract_text_from_pdf($uri, $offset, $raw_text = FALSE, $layout = TRUE) {
+function islandora_paged_content_extract_text_from_pdf($uri, $offset, $layout = TRUE, $raw_text = FALSE) {
   $file_path = drupal_realpath($uri);
   // PDF doesn't exist or pdftotext isn't available, abort.
   if (!file_exists($file_path) || !islandora_paged_content_pdftotext_availability()) {

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -908,21 +908,22 @@ function islandora_paged_content_pdfinfo_availability() {
  *   The page number to extract it will be used as the first and last page
  *   value. Note that pdftotext won't complain about using an offset greater
  *   than the number of allotted pages of a PDF.
- *
+ * @param bool $raw_text
+ *   Whether to extract the raw text from the PDF or not.
  * @param bool $layout
  *   Whether we are retaining layout of the PDF or not.
  *
  * @return bool|string
  *   FALSE if it fails, the URI of the text file otherwise.
  */
-function islandora_paged_content_extract_text_from_pdf($uri, $offset, $layout = TRUE) {
+function islandora_paged_content_extract_text_from_pdf($uri, $offset, $raw_text = FALSE, $layout = TRUE) {
   $file_path = drupal_realpath($uri);
   // PDF doesn't exist or pdftotext isn't available, abort.
   if (!file_exists($file_path) || !islandora_paged_content_pdftotext_availability()) {
     return FALSE;
   }
   $pdftotext = variable_get('islandora_paged_content_pdftotext', '/usr/bin/pdftotext');
-  $base_command = '!pdftotext_path !layout -f !offset -l !offset !pdf_uri !output_file';
+  $base_command = '!pdftotext_path !raw !layout -f !offset -l !offset !pdf_uri !output_file';
   $output_file = drupal_tempnam('temporary://', 'full');
 
   // Need to link the file because of UTF-8 encoding.
@@ -933,6 +934,7 @@ function islandora_paged_content_extract_text_from_pdf($uri, $offset, $layout = 
     '!offset' => $offset,
     '!pdf_uri' => escapeshellarg(drupal_realpath($copy)),
     '!output_file' => drupal_realpath($output_file),
+    '!raw' => $raw_text ? '-raw' : '',
   ));
   $output = array();
   $ret = 0;

--- a/islandora_paged_content.install
+++ b/islandora_paged_content.install
@@ -22,6 +22,7 @@ function islandora_paged_content_uninstall() {
     'islandora_paged_content_gs',
     'islandora_paged_content_pdfinfo',
     'islandora_paged_content_pdftotext',
+    'islandora_paged_content_pdftotext_use_raw',
   );
   array_walk($variables, 'variable_del');
 }

--- a/tests/pdftotext.test
+++ b/tests/pdftotext.test
@@ -70,11 +70,11 @@ class PDFToTextTestCase extends DrupalUnitTestCase {
     $test_mcmaster_pdf = drupal_get_path('module', 'islandora_paged_content') . '/tests/fixtures/arl-carl-statement-supporting-askey-mcmaster-final.pdf';
     $fixture_text_mcmaster = drupal_get_path('module', 'islandora_paged_content') . '/tests/fixtures/mcmaster_text_no_layout_page1.txt';
 
-    $test_mcgill_text_uri = islandora_paged_content_extract_text_from_pdf($test_mcgill_pdf, 4, FALSE);
+    $test_mcgill_text_uri = islandora_paged_content_extract_text_from_pdf($test_mcgill_pdf, 4, FALSE, FALSE);
     $this->assertEqual(file_get_contents($test_mcgill_text_uri), file_get_contents($fixture_text_mcgill), 'The extracted text matches the contents of the McGill fixture.');
     file_unmanaged_delete($test_mcgill_text_uri);
 
-    $test_mcmaster_text_uri = islandora_paged_content_extract_text_from_pdf($test_mcmaster_pdf, 1, FALSE);
+    $test_mcmaster_text_uri = islandora_paged_content_extract_text_from_pdf($test_mcmaster_pdf, 1, FALSE, FALSE);
     $this->assertEqual(file_get_contents($test_mcmaster_text_uri), file_get_contents($fixture_text_mcmaster), 'The extracted text matches the contents of the McMaster fixture.');
     file_unmanaged_delete($test_mcmaster_text_uri);
   }

--- a/tests/pdftotext.test
+++ b/tests/pdftotext.test
@@ -70,14 +70,15 @@ class PDFToTextTestCase extends DrupalUnitTestCase {
     $test_mcmaster_pdf = drupal_get_path('module', 'islandora_paged_content') . '/tests/fixtures/arl-carl-statement-supporting-askey-mcmaster-final.pdf';
     $fixture_text_mcmaster = drupal_get_path('module', 'islandora_paged_content') . '/tests/fixtures/mcmaster_text_no_layout_page1.txt';
 
-    $test_mcgill_text_uri = islandora_paged_content_extract_text_from_pdf($test_mcgill_pdf, 4, FALSE, FALSE);
+    $test_mcgill_text_uri = islandora_paged_content_extract_text_from_pdf($test_mcgill_pdf, 4, FALSE);
     $this->assertEqual(file_get_contents($test_mcgill_text_uri), file_get_contents($fixture_text_mcgill), 'The extracted text matches the contents of the McGill fixture.');
     file_unmanaged_delete($test_mcgill_text_uri);
 
-    $test_mcmaster_text_uri = islandora_paged_content_extract_text_from_pdf($test_mcmaster_pdf, 1, FALSE, FALSE);
+    $test_mcmaster_text_uri = islandora_paged_content_extract_text_from_pdf($test_mcmaster_pdf, 1, FALSE);
     $this->assertEqual(file_get_contents($test_mcmaster_text_uri), file_get_contents($fixture_text_mcmaster), 'The extracted text matches the contents of the McMaster fixture.');
     file_unmanaged_delete($test_mcmaster_text_uri);
   }
+
   /**
    * Test that a non-valid URI returns FALSE.
    */


### PR DESCRIPTION
**JIRA:** https://jira.duraspace.org/browse/ISLANDORA-1536
# What does this Pull Request do?

Adds the ability to pass the raw parameter off to pdftotext for text extraction.
# How should this be tested?

Enable the toggleable checkbox to expose this feature through the paged content admin page located at yoursite/admin/islandora/solution_pack_config/paged_content
Go through the ingest process for a book or newspaper issue object.
Include a PDF file to be processed
Select the extract text option
Select whether to use raw text or not
# Screenshots
## Before Screenshot

![screen shot 2015-11-04 at 3 22 40 pm](https://cloud.githubusercontent.com/assets/1337738/10949175/f9dc579c-8307-11e5-8e12-4b532f79464c.png)
## After Screenshot

![screen shot 2015-11-05 at 3 08 14 pm](https://cloud.githubusercontent.com/assets/1337738/10978786/20f287f8-83cf-11e5-998a-530dc94d41d9.png)

**Tagging:** @Islandora/7-x-1-x-committers 

---

Jordan Dukart
_Developer_
**[discoverygarden inc.](http://www.discoverygarden.ca) | Managing Digital Content**
