### PR TITLE
Optional Solr querying for pages and dimensions.

### DIFF
--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -116,7 +116,34 @@ function islandora_paged_content_admin_settings_form(array $form, array &$form_s
       '#description' => t('The page or sequence number of each page or image.'),
       '#default_value' => $get_default_value('islandora_paged_content_sequence_number_field', 'RELS_EXT_isSequenceNumber_literal_ms'),
     ),
-
+    'islandora_paged_content_use_solr_for_dimensions' => array(
+      '#access' => $solr_enabled,
+      '#type' => 'checkbox',
+      '#title' => t('Use Solr to derive pages and sequence numbers'),
+      '#default_value' => $get_default_value('islandora_paged_content_use_solr_for_dimensions', FALSE),
+    ),
+    'islandora_paged_content_solr_width_field' => array(
+      '#access' => $solr_enabled,
+      '#type' => 'textfield',
+      '#title' => t('Solr width dimension field'),
+      '#default_value' => $get_default_value('islandora_paged_content_solr_width_field', 'RELS_INT_width_literal_s'),
+      '#states' => array(
+        'visible' => array(
+          ':input[name="islandora_paged_content_use_solr_for_dimensions"]' => array('checked' => TRUE),
+        ),
+      ),
+    ),
+    'islandora_paged_content_solr_height_field' => array(
+      '#access' => $solr_enabled,
+      '#type' => 'textfield',
+      '#title' => t('Solr height dimension field'),
+      '#default_value' => $get_default_value('islandora_paged_content_solr_height_field', 'RELS_INT_height_literal_s'),
+      '#states' => array(
+        'visible' => array(
+          ':input[name="islandora_paged_content_use_solr_for_dimensions"]' => array('checked' => TRUE),
+        ),
+      ),
+    ),
     'islandora_paged_content_page_label' => array(
       '#type' => 'checkbox',
       '#title' => t('Set page labels to sequence numbers'),

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -21,23 +21,59 @@
  *   number. Each an array containing info.
  */
 function islandora_paged_content_get_pages(AbstractObject $object) {
-  $query = <<<EOQ
-PREFIX islandora-rels-ext: <http://islandora.ca/ontology/relsext#>
-SELECT ?pid ?page ?label ?width ?height
-FROM <#ri>
-WHERE {
-  ?pid <fedora-rels-ext:isMemberOf> <info:fedora/{$object->id}> ;
-       <fedora-model:label> ?label ;
-       islandora-rels-ext:isSequenceNumber ?page ;
-       <fedora-model:state> <fedora-model:Active> .
-  OPTIONAL {
-    ?pid <fedora-view:disseminates> ?dss .
-    ?dss <fedora-view:disseminationType> <info:fedora/*/JP2> ;
-         islandora-rels-ext:width ?width ;
-         islandora-rels-ext:height ?height .
- }
+  $pages = array();
+  // Try to use Solr first if enabled, or default to the RI if the Solr query
+  // fails for some reason.
+  if (variable_get('islandora_paged_content_use_solr_for_dimensions', FALSE)) {
+    $pages = islandora_paged_content_get_pages_solr($object);
+    if (empty($pages)) {
+      $pages = islandora_paged_content_get_pages_ri($object);
+    }
+  }
+  else {
+    $pages = islandora_paged_content_get_pages_ri($object);
+  }
+  // Sort the pages into their proper order.
+  $sort = function($a, $b) {
+    $a = (is_array($a) && isset($a['page'])) ? $a['page'] : 0;
+    $b = (is_array($b) && isset($b['page'])) ? $b['page'] : 0;
+    if ($a == $b) {
+      return 0;
+    }
+    return ($a < $b) ? -1 : 1;
+  };
+  uasort($pages, $sort);
+  return $pages;
 }
-ORDER BY ?page
+
+/**
+ * Helper function to retrieve the pages and dimensions from the RI.
+ *
+ * @param AbstractObject $object
+ *   An AbstractObject representing a book.
+ *
+ * @return array
+ *   All the pages in the given paged content object. Ordered by sequence
+ *   number. Each an array containing info.
+ */
+function islandora_paged_content_get_pages_ri($object) {
+  $query = <<<EOQ
+  PREFIX islandora-rels-ext: <http://islandora.ca/ontology/relsext#>
+  SELECT ?pid ?page ?label ?width ?height
+  FROM <#ri>
+  WHERE {
+    ?pid <fedora-rels-ext:isMemberOf> <info:fedora/{$object->id}> ;
+         <fedora-model:label> ?label ;
+         islandora-rels-ext:isSequenceNumber ?page ;
+         <fedora-model:state> <fedora-model:Active> .
+    OPTIONAL {
+      ?pid <fedora-view:disseminates> ?dss .
+      ?dss <fedora-view:disseminationType> <info:fedora/*/JP2> ;
+           islandora-rels-ext:width ?width ;
+           islandora-rels-ext:height ?height .
+   }
+  }
+  ORDER BY ?page
 EOQ;
 
   $results = $object->repository->ri->sparqlQuery($query);
@@ -63,18 +99,53 @@ EOQ;
   // If we have some pages, combine our remapped results to produce an array
   // mapping pids to the values for that pid.
   $pages = count($pids) ? array_combine($pids, $pages) : array();
+  return $pages;
+}
 
-  // Sort the pages into their proper order.
-  $sort = function($a, $b) {
-    $a = (is_array($a) && isset($a['page'])) ? $a['page'] : 0;
-    $b = (is_array($b) && isset($b['page'])) ? $b['page'] : 0;
-    if ($a == $b) {
-      return 0;
+/**
+ * Helper function to retrieve the pages and dimensions from Solr.
+ *
+ * @param AbstractObject $object
+ *   An AbstractObject representing a book.
+ *
+ * @return array
+ *   All the pages in the given paged content object. Ordered by sequence
+ *   number. Each an array containing info.
+ */
+function islandora_paged_content_get_pages_solr(AbstractObject $object) {
+  $pages = array();
+  $qp = new islandoraSolrQueryProcessor();
+  $qp->buildQuery(format_string('@field:"@pid"', array(
+      '@field' => variable_get('islandora_solr_member_of_field', 'RELS_EXT_isMemberOf_uri_ms'),
+      '@pid' => "info:fedora/{$object->id}")
+  ));
+  $label_field = variable_get('islandora_solr_object_label_field', 'fgs_label_s');
+  $sequence_field = variable_get('islandora_paged_content_sequence_number_field', 'RELS_EXT_isSequenceNumber_literal_ms');
+  $height_field = variable_get('islandora_paged_content_solr_height_field', 'RELS_INT_height_literal_s');
+  $width_field = variable_get('islandora_paged_content_solr_width_field', 'RELS_INT_width_literal_s');
+  $qp->solrParams['fl'] = implode(', ', array(
+    'PID',
+    $label_field,
+    $sequence_field,
+    $height_field,
+    $width_field,
+  ));
+  $qp->executeQuery(FALSE);
+  if ($qp->islandoraSolrResult['response']['numFound'] > 0) {
+    foreach ($qp->islandoraSolrResult['response']['objects'] as $page) {
+      $pages[$page['PID']] = array(
+        'pid' => $page['PID'],
+        'page' => (string) reset($page['solr_doc'][$sequence_field]),
+        'label' => $page['object_label'],
+      );
+      if (isset($page['solr_doc'][$width_field])) {
+        $pages[$page['PID']]['width'] = $page['solr_doc'][$width_field];
+      }
+      if (isset($page['solr_doc'][$height_field])) {
+        $pages[$page['PID']]['height'] = $page['solr_doc'][$height_field];
+      }
     }
-    return ($a < $b) ? -1 : 1;
-  };
-  uasort($pages, $sort);
-
+  }
   return $pages;
 }
 

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -130,6 +130,7 @@ function islandora_paged_content_get_pages_solr(AbstractObject $object) {
     $height_field,
     $width_field,
   ));
+  $qp->solrLimit = 100000;
   $qp->executeQuery(FALSE);
   if ($qp->islandoraSolrResult['response']['numFound'] > 0) {
     foreach ($qp->islandoraSolrResult['response']['objects'] as $page) {

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -24,7 +24,7 @@ function islandora_paged_content_get_pages(AbstractObject $object) {
   $pages = array();
   // Try to use Solr first if enabled, or default to the RI if the Solr query
   // fails for some reason.
-  if (variable_get('islandora_paged_content_use_solr_for_dimensions', FALSE)) {
+  if (module_exists('islandora_solr') && variable_get('islandora_paged_content_use_solr_for_dimensions', FALSE)) {
     $pages = islandora_paged_content_get_pages_solr($object);
     if (empty($pages)) {
       $pages = islandora_paged_content_get_pages_ri($object);
@@ -56,7 +56,7 @@ function islandora_paged_content_get_pages(AbstractObject $object) {
  *   All the pages in the given paged content object. Ordered by sequence
  *   number. Each an array containing info.
  */
-function islandora_paged_content_get_pages_ri($object) {
+function islandora_paged_content_get_pages_ri(AbstractObject $object) {
   $query = <<<EOQ
   PREFIX islandora-rels-ext: <http://islandora.ca/ontology/relsext#>
   SELECT ?pid ?page ?label ?width ?height


### PR DESCRIPTION
**Jira:** https://jira.duraspace.org/browse/ISLANDORA-1607 
# What does this Pull Request do?

This pull request allows for the Solr index to be queried as opposed to the RI when retrieving pages for use within Islandora.
# How should this be tested?

Toggle the checkbox in the configuration for the paged content module and ensure that the three Solr fields for the "Solr width", "Solr height" and "Solr page sequence" field are configured correctly. Note that the before and after rendering of pages is the same in both the viewer and pages tab. 
# Background context:

This pull allows for improved performance on sites with large RIs to traverse when retrieving pages.
# Screenshots
## Before Screenshot

![Before Screenshot](https://cloud.githubusercontent.com/assets/1337738/12896875/bd24159c-ce7a-11e5-9100-29dc9c8864f2.png)
## After Screenshot

![After Screenshot](https://cloud.githubusercontent.com/assets/1337738/12896887/c864ad5e-ce7a-11e5-8223-2037f6d36194.png)
# Additional Notes:
- **Does this change require documentation to be updated?** Probably should note that this is possible.
- **Does this change add any new dependencies?** No this takes light of a soft dependency already existing within paged content
- **Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)?** No
- **Could this change impact execution of existing code?** No

**Tagging:** @whikloj

---

Jordan Dukart
_Developer_
**[discoverygarden inc.](http://www.discoverygarden.ca) | Managing Digital Content**
