### PR TITLE
ISLANDORA-1867: permit html markup in last sequence number field description on "Add Zipped Pages"

### DIFF
--- a/includes/manage_pages.inc
+++ b/includes/manage_pages.inc
@@ -595,7 +595,7 @@ function islandora_paged_content_zipped_upload_form(array $form, array &$form_st
       '#type' => 'textfield',
       '#title' => t('Last sequence number'),
       '#default_value' => $last_page_number,
-      '#description' => filter_xss_admin($message),
+      '#description' => $message,
       '#size' => 5,
     );
   }

--- a/includes/manage_pages.inc
+++ b/includes/manage_pages.inc
@@ -595,7 +595,7 @@ function islandora_paged_content_zipped_upload_form(array $form, array &$form_st
       '#type' => 'textfield',
       '#title' => t('Last sequence number'),
       '#default_value' => $last_page_number,
-      '#description' => check_plain($message),
+      '#description' => filter_xss_admin($message),
       '#size' => 5,
     );
   }


### PR DESCRIPTION
**JIRA Ticket**: (https://jira.duraspace.org/browse/ISLANDORA-1867)

# What does this Pull Request do?

On the add zipped pages form (e.g. islandora/object/%islandora_object/manage/book/ingest_zipped), the last sequence number field description shows escaped markup. This pull request permits the desired markup to be expressed.

# What's new?
On line 598 of [includes/manage_pages.inc](https://github.com/Islandora/islandora_paged_content/blob/7.x/includes/manage_pages.inc#L598), we take out `check_plain()` which permits the `<br>` in $msg to be expressed without escaping.  

Example:
* Changes this:
![screen shot 2016-12-15 at 3 37 59 pm](https://cloud.githubusercontent.com/assets/241240/21241215/981e4482-c2dc-11e6-9359-b09f9c58bf81.png)
* To this:
![screen shot 2016-12-15 at 3 36 34 pm](https://cloud.githubusercontent.com/assets/241240/21241235/a96f2a1c-c2dc-11e6-9e46-cfa386ca6c0c.png)

# How should this be tested?

* Find a paged content object (book or newspaper), click "manage" > "book" or "newspaper" then click on the "Add Zipped Pages" link. 
* Current behavior is that a `<br>` tag appears escaped in the field description for "Last sequence number"
* After applying this pull request, the `<br>` tag is expressed as a new line.

# Additional Notes:
Any additional information that you think would be helpful when reviewing this PR.

* Does this change require documentation to be updated? - *NO*
* Does this change add any new dependencies? - *NO*
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? - *NO*
* Could this change impact execution of existing code? - *No, but if the $msg content is changed in the future to use html tags that need to be sanitized, we would need to revisit.*

# Interested parties
@Islandora/7-x-1-x-committers