### PR TITLE
7.x islandora paged content 1880

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: required
 language: php
 php:
   - 5.3.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,4 +34,4 @@ script:
   - $ISLANDORA_DIR/tests/scripts/line_endings.sh sites/all/modules/islandora_paged_content
   - drush coder-review --reviews=production,security,style,i18n,potx,sniffer islandora_paged_content
   - phpcpd --names *.module,*.inc,*.test sites/all/modules/islandora_paged_content
-  - drush test-run --uri=http://localhost:8081 "Islandora Paged Content"
+  - php scripts/run-tests.sh --php `phpenv which php` --url http://localhost:8081 --verbose "Islandora Paged Content"

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,10 @@ before_install:
   - sudo sh $TRAVIS_BUILD_DIR/tests/scripts/poppler-utils-install.sh
   - sudo sh $TRAVIS_BUILD_DIR/tests/scripts/ghostscript-install.sh
   - drush en --yes islandora_paged_content
+before_script:
+
+  # Mysql might time out for long tests, increase the wait timeout.
+  - mysql -e 'SET @@GLOBAL.wait_timeout=1200'
 script:
   - ant -buildfile sites/all/modules/islandora_paged_content/build.xml lint
   - $ISLANDORA_DIR/tests/scripts/line_endings.sh sites/all/modules/islandora_paged_content


### PR DESCRIPTION
JIRA Ticket: https://jira.duraspace.org/browse/ISLANDORA-1880

What does this Pull Request do?

Replaces Travis-CI Drupal Test invocations made via Drush, which are being deprecated, with Drupal's provided PHP scripts. Updates the YAML to have a MySQL timeout so that long running tests don't cause the MySQL session to timeout. Lastly, adds sudo for the YAML as old builds were grandfathered.

What's new?

Modified the .travis.yml file from Drush to the drupal script. Added Sudo in .travis.yml file as it required for the scrips to run, repos before 2015 were grandfathered in. However, this isn't the case for forks. Also, added a before_script in travis.yml file to extend mysql wait time to 1200 as the builds were failing in Travic-ci.org.

Interested parties

@Islandora/7-x-1-x-committers