### PR TITLE
restores some type of sanitising

### DIFF
--- a/includes/manage_pages.inc
+++ b/includes/manage_pages.inc
@@ -595,7 +595,7 @@ function islandora_paged_content_zipped_upload_form(array $form, array &$form_st
       '#type' => 'textfield',
       '#title' => t('Last sequence number'),
       '#default_value' => $last_page_number,
-      '#description' => $message,
+      '#description' => filter_xss_admin($message),
       '#size' => 5,
     );
   }


### PR DESCRIPTION
**JIRA Ticket**: [ISLANDORA-1927](https://jira.duraspace.org/browse/ISLANDORA-1927)
And previous pull https://github.com/Islandora/islandora_paged_content/pull/120

# What does this Pull Request do?

Allows Travis, in specific `phpcs` using drupal coding standards, to pass again. My fault. Asked @patdunlavey on #120 to remove all santitisation functions because the value used in the affected form key was already clean. But `phpcs` requires that to happen in that exact line or something like 
````
sites/all/modules/islandora_paged_content/includes/manage_pages.inc:
 +598: [critical] Potential problem: FAPI elements '#title' and '#description' only 
accept filtered text, be sure to use check_plain 
http://api.drupal.org/api/function/check_plain/(), 
filter_xss http://api.drupal.org/api/function/filter_xss/() or similar to
 ensure your $variable is fully sanitized
````

happens

# What's new?
A working travis-CI again

# How should this be tested?
Nothing to test really. If travis-CI passes means it is fixed. Was not passing before this pull.

# Additional Notes:

A pull request against 7.x-1.9 will be made once this one passes Travis-CI

# Interested parties
@patdunlavey @whikloj 