### PR TITLE
ISLANDORA-1981: Add MODS to composite ds model 

### DIFF
--- a/xml/islandora_pageCModel_ds_composite_model.xml
+++ b/xml/islandora_pageCModel_ds_composite_model.xml
@@ -1,13 +1,16 @@
 <?xml version="1.0"?>
 <dsCompositeModel xmlns="info:fedora/fedora-system:def/dsCompositeModel#">
   <dsTypeModel ID="DC">
-    <form FORMAT_URI="http://www.openarchives.org/OAI/2.0/oai_dc/" MIME="text/xml"/>
+    <form FORMAT_URI="http://www.openarchives.org/OAI/2.0/oai_dc/" MIME="application/xml"/>
   </dsTypeModel>
   <dsTypeModel ID="RELS-EXT" optional="true">
     <form FORMAT_URI="info:fedora/fedora-system:FedoraRELSExt-1.0" MIME="application/rdf+xml"/>
   </dsTypeModel>
   <dsTypeModel ID="RELS-INT" optional="true">
     <form FORMAT_URI="info:fedora/fedora-system:FedoraRELSInt-1.0" MIME="application/rdf+xml"/>
+  </dsTypeModel>
+   <dsTypeModel ID="MODS" optional="true">
+    <form FORMAT_URI="http://www.loc.gov/mods/v3" MIME="application/xml"/>
   </dsTypeModel>
   <dsTypeModel ID="OBJ" optional="false">
     <form MIME="image/tiff"/>


### PR DESCRIPTION
**[ISLANDORA-1981](https://jira.duraspace.org/browse/ISLANDORA-1981)**
 and
**[ISLANDORA-1045](https://jira.duraspace.org/browse/ISLANDORA-1045)**

# What does this Pull Request do?

Adds a MODS datastream slot to `islandora:pageCMODEL` definition.

# What's new?
Now Book pages are officially allowed to have page-level metadata in MODS. 
Bonus:  ISLANDORA-1045 was not fully resolved. DC datastream was made `application/xml` to avoid having two different XML mime types in the same file.

# How should this be tested?

- Apply this pull request
- Go to admin/islandora/solution_pack_config/solution_packs and reinstall islandora:pageCMODEL
- Go to an existing book, or ingest a single Islandora page somewhere in your repo
- You should be able to add MODS data stream via `manage/datastreams/add` (MODS will be marked as missing and autocomplete) and associating  XML forms to MODS in pages is possible.

# Additional Notes:
Should revisit other composite ds XML files?

# Interested parties
@willtp87 or any other  @Islandora/7-x-1-x-committers interessted in MODS