### PR TITLE
Only ingest the datastream if it does not already exist.

### DIFF
--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -1258,7 +1258,8 @@ function islandora_paged_content_can_extract_from_pdf() {
  */
 function islandora_paged_content_add_pdf_to_object(AbstractObject $object, $file_obj, $batch = FALSE) {
   module_load_include('inc', 'islandora_paged_content', 'includes/db');
-  if (!isset($object['PDF'])) {
+  $ingest = !isset($object['PDF']);
+  if ($ingest) {
     $pdf = $object->constructDatastream('PDF', 'M');
   }
   else {
@@ -1271,7 +1272,9 @@ function islandora_paged_content_add_pdf_to_object(AbstractObject $object, $file
   if ($pdf->mimetype != $file_obj->filemime) {
     $pdf->mimetype = $file_obj->filemime;
   }
-  $object->ingestDatastream($pdf);
+  if ($ingest) {
+    $object->ingestDatastream($pdf);
+  }
   if (!$batch) {
     islandora_paged_content_track_pdf_ingestion($object->id, $file_obj->fid);
   }


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1995

# What does this Pull Request do?
Does not attempt to ingest an existing datastream when "updating" as this behavior will become deprecated in 7.x-1.10.

# What's new?
Datastream does not attempt to be ingested but is instead updated.

# How should this be tested?
Ingest a new book object.
On the optional PDF upload form appears, upload a PDF.
Note the PDF gets ingested as previously.

# Additional Notes:
The current implementations wouldn't get affected by this but if this utility function was being used elsewhere it could possibly throw an exception.

Example:
* Does this change require documentation to be updated?  No.
* Does this change add any new dependencies?  No.
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? No.
* Could this change impact execution of existing code? No.

# Interested parties
@Islandora/7-x-1-x-committers 
