### PR TITLE
add ocr/hocr ignoring options

### DIFF
--- a/includes/derivatives.inc
+++ b/includes/derivatives.inc
@@ -182,3 +182,23 @@ function islandora_paged_content_remove_ocr_flag(AbstractObject $object) {
 function islandora_paged_content_set_ocr_flag(AbstractObject $object) {
   $object->relationships->add(ISLANDORA_RELS_EXT_URI, 'create_ocr', 'true', RELS_TYPE_PLAIN_LITERAL);
 }
+
+/**
+ * Removes the HOCR derivative creation flag.
+ *
+ * @param AbstractObject $object
+ *   The object to remove the relationship from.
+ */
+function islandora_paged_content_remove_hocr_flag(AbstractObject $object) {
+  $object->relationships->remove(ISLANDORA_RELS_EXT_URI, 'create_hocr', 'true', RELS_TYPE_PLAIN_LITERAL);
+}
+
+/**
+ * Sets the HOCR derivative creation flag.
+ *
+ * @param AbstractObject $object
+ *   The object to set the relationship on.
+ */
+function islandora_paged_content_set_hocr_flag(AbstractObject $object) {
+  $object->relationships->add(ISLANDORA_RELS_EXT_URI, 'create_hocr', 'true', RELS_TYPE_PLAIN_LITERAL);
+}

--- a/includes/derivatives.inc
+++ b/includes/derivatives.inc
@@ -182,23 +182,3 @@ function islandora_paged_content_remove_ocr_flag(AbstractObject $object) {
 function islandora_paged_content_set_ocr_flag(AbstractObject $object) {
   $object->relationships->add(ISLANDORA_RELS_EXT_URI, 'create_ocr', 'true', RELS_TYPE_PLAIN_LITERAL);
 }
-
-/**
- * Removes the HOCR derivative creation flag.
- *
- * @param AbstractObject $object
- *   The object to remove the relationship from.
- */
-function islandora_paged_content_remove_hocr_flag(AbstractObject $object) {
-  $object->relationships->remove(ISLANDORA_RELS_EXT_URI, 'create_hocr', 'true', RELS_TYPE_PLAIN_LITERAL);
-}
-
-/**
- * Sets the HOCR derivative creation flag.
- *
- * @param AbstractObject $object
- *   The object to set the relationship on.
- */
-function islandora_paged_content_set_hocr_flag(AbstractObject $object) {
-  $object->relationships->add(ISLANDORA_RELS_EXT_URI, 'create_hocr', 'true', RELS_TYPE_PLAIN_LITERAL);
-}

--- a/includes/manage_pages.inc
+++ b/includes/manage_pages.inc
@@ -798,11 +798,13 @@ function islandora_paged_content_add_pages($repository, $config, $pages_director
   $parent = $config['pid'];
   $object->relationships->add(FEDORA_MODEL_URI, 'hasModel', $config['model']);
 
-  if ($config['ignored_derivs']['ocr']) {
-    islandora_paged_content_set_relationship($rels_ext, ISLANDORA_RELS_EXT_URI, 'generate_ocr', 'FALSE', TRUE);
-  }
-  if ($config['ignored_derivs']['hocr']) {
-    islandora_paged_content_set_relationship($rels_ext, ISLANDORA_RELS_EXT_URI, 'generate_hocr', 'FALSE', TRUE);
+  // Re-checking module existence here in case this batch op is called from
+  // somewhere other than the form.
+  if (module_exists('islandora_ocr')) {
+    module_load_include('inc', 'islandora_ocr', 'includes/derivatives');
+    $generate_ocr = isset($config['ignored_derivs']['ocr'] ? FALSE : NULL;
+    $generate_hocr = isset($config['ignored_derivs']['hocr'] ? FALSE : NULL;
+    islandora_ocr_set_generating_rels_ext_statements($object, $generate_ocr, $generate_hocr);
   }
   islandora_paged_content_set_relationship($rels_ext, ISLANDORA_RELS_EXT_URI, 'hasLanguage', $config['language'], TRUE);
   islandora_paged_content_set_relationship($rels_ext, ISLANDORA_RELS_EXT_URI, 'isPageOf', $parent);

--- a/includes/manage_pages.inc
+++ b/includes/manage_pages.inc
@@ -568,27 +568,27 @@ function islandora_paged_content_ingest_zipped_pages(AbstractObject $object, $al
  *   Drupal form definition.
  */
 function islandora_paged_content_zipped_upload_form(array $form, array &$form_state, $pid, $allowed_extensions, $model, $derivatives) {
-  module_load_include('inc', 'islandora_ocr', 'includes/utilities');
   module_load_include('inc', 'islandora_paged_content', 'includes/utilities');
   $object = islandora_object_load($pid);
   $current_pages = islandora_paged_content_get_pages($object);
   $last_page_number = count($current_pages);
-  $languages = module_exists('islandora_ocr') ? islandora_ocr_get_enabled_tesseract_languages() : array();
   $upload_size = min((int) ini_get('post_max_size'), (int) ini_get('upload_max_filesize'));
   $extensions = array('zip');
   $form = array();
-  $do_ocr = in_array('ocr', $derivatives) && module_exists('islandora_ocr');
   $message = t("This sequence currently has @count pages. Additional pages will be appended to the end of the sequence by default. !break", array("@count" => $last_page_number, '!break' => '<br />'));
   $message .= t("Choose a number lower than @count to insert page(s) at a specific location in the sequence.", array("@count" => $last_page_number, '!break' => '<br />'));
 
-  $form['language'] = array(
-    '#access' => module_exists('islandora_ocr') && $do_ocr,
-    '#title' => t('Language'),
-    '#type' => 'select',
-    '#description' => t('Please select the language the page is written in.'),
-    '#options' => $languages,
-    '#default_value' => 'English',
-  );
+  if (module_exists('islandora_ocr') && in_array('ocr', $derivatives)) {
+    module_load_include('inc', 'islandora_ocr', 'includes/utilities');
+    $form['language'] = array(
+      '#title' => t('Language'),
+      '#type' => 'select',
+      '#description' => t('Please select the language the page is written in.'),
+      '#options' => islandora_ocr_get_enabled_tesseract_languages(),
+      '#default_value' => 'English',
+    );
+    $form['ignored_ocr_derivatives'] = islandora_ocr_get_ignored_derivatives_fieldset();
+  }
 
   if ($current_pages) {
     $form['insertion_point'] = array(
@@ -739,6 +739,10 @@ function islandora_paged_content_zipped_upload_form_submit(array $form, array &$
       'model' => $form_state['values']['model'],
       'file_count' => $file_count,
       'book_label' => $book_label,
+      'ignored_derivs' => array(
+        'ocr' => $form_state['values']['ignore_ocr'],
+        'hocr' => $form_state['values']['ignore_hocr'],
+      ),
     );
     if (isset($pages_to_renumber[0])) {
       foreach ($pages_to_renumber as $page) {
@@ -794,6 +798,12 @@ function islandora_paged_content_add_pages($repository, $config, $pages_director
   $parent = $config['pid'];
   $object->relationships->add(FEDORA_MODEL_URI, 'hasModel', $config['model']);
 
+  if ($config['ignored_derivs']['ocr']) {
+    islandora_paged_content_set_relationship($rels_ext, ISLANDORA_RELS_EXT_URI, 'generate_ocr', 'FALSE', TRUE);
+  }
+  if ($config['ignored_derivs']['hocr']) {
+    islandora_paged_content_set_relationship($rels_ext, ISLANDORA_RELS_EXT_URI, 'generate_hocr', 'FALSE', TRUE);
+  }
   islandora_paged_content_set_relationship($rels_ext, ISLANDORA_RELS_EXT_URI, 'hasLanguage', $config['language'], TRUE);
   islandora_paged_content_set_relationship($rels_ext, ISLANDORA_RELS_EXT_URI, 'isPageOf', $parent);
   islandora_paged_content_set_relationship($rels_ext, ISLANDORA_RELS_EXT_URI, 'isSequenceNumber', (string) $config['page_number'], TRUE);

--- a/includes/manage_pages.inc
+++ b/includes/manage_pages.inc
@@ -580,13 +580,16 @@ function islandora_paged_content_zipped_upload_form(array $form, array &$form_st
 
   if (module_exists('islandora_ocr') && in_array('ocr', $derivatives)) {
     module_load_include('inc', 'islandora_ocr', 'includes/utilities');
+    $languages = islandora_ocr_get_enabled_tesseract_languages();
     $form['language'] = array(
       '#title' => t('Language'),
       '#type' => 'select',
       '#description' => t('Please select the language the page is written in.'),
-      '#options' => islandora_ocr_get_enabled_tesseract_languages(),
-      '#default_value' => 'English',
+      '#options' => $languages,
     );
+    if (in_array('English', $languages)) {
+      $form['language']['#default_value'] = 'eng';
+    }
     $form['ignored_ocr_derivatives'] = islandora_ocr_get_ignored_derivatives_fieldset();
   }
 

--- a/includes/manage_pages.inc
+++ b/includes/manage_pages.inc
@@ -802,8 +802,8 @@ function islandora_paged_content_add_pages($repository, $config, $pages_director
   // somewhere other than the form.
   if (module_exists('islandora_ocr')) {
     module_load_include('inc', 'islandora_ocr', 'includes/derivatives');
-    $generate_ocr = isset($config['ignored_derivs']['ocr'] ? FALSE : NULL;
-    $generate_hocr = isset($config['ignored_derivs']['hocr'] ? FALSE : NULL;
+    $generate_ocr = isset($config['ignored_derivs']['ocr']) ? FALSE : NULL;
+    $generate_hocr = isset($config['ignored_derivs']['hocr']) ? FALSE : NULL;
     islandora_ocr_set_generating_rels_ext_statements($object, $generate_ocr, $generate_hocr);
   }
   islandora_paged_content_set_relationship($rels_ext, ISLANDORA_RELS_EXT_URI, 'hasLanguage', $config['language'], TRUE);

--- a/includes/manage_pages.inc
+++ b/includes/manage_pages.inc
@@ -731,7 +731,6 @@ function islandora_paged_content_zipped_upload_form_submit(array $form, array &$
     );
     $file_count = count($files_to_add);
     $config = array(
-      'language' => $language,
       'pid' => $pid,
       'destination_dir' => $destination_dir,
       'namespace' => $namespace,
@@ -739,9 +738,10 @@ function islandora_paged_content_zipped_upload_form_submit(array $form, array &$
       'model' => $form_state['values']['model'],
       'file_count' => $file_count,
       'book_label' => $book_label,
+      'language' => isset($form_state['values']['language']) ? $form_state['values']['language'] : 'English',
       'ignored_derivs' => array(
-        'ocr' => $form_state['values']['ignore_ocr'],
-        'hocr' => $form_state['values']['ignore_hocr'],
+        'ocr' => isset($form_state['values']['ignore_ocr']) ? $form_state['values']['ignore_ocr'] : FALSE,
+        'hocr' => isset($form_state['values']['ignore_hocr']) ? $form_state['values']['ignore_hocr'] : FALSE,
       ),
     );
     if (isset($pages_to_renumber[0])) {

--- a/includes/manage_pages.inc
+++ b/includes/manage_pages.inc
@@ -741,7 +741,7 @@ function islandora_paged_content_zipped_upload_form_submit(array $form, array &$
       'model' => $form_state['values']['model'],
       'file_count' => $file_count,
       'book_label' => $book_label,
-      'language' => isset($form_state['values']['language']) ? $form_state['values']['language'] : 'English',
+      'language' => isset($form_state['values']['language']) ? $form_state['values']['language'] : 'eng',
       'ignored_derivs' => array(
         'ocr' => isset($form_state['values']['ignore_ocr']) ? $form_state['values']['ignore_ocr'] : FALSE,
         'hocr' => isset($form_state['values']['ignore_hocr']) ? $form_state['values']['ignore_hocr'] : FALSE,
@@ -805,9 +805,8 @@ function islandora_paged_content_add_pages($repository, $config, $pages_director
   // somewhere other than the form.
   if (module_exists('islandora_ocr')) {
     module_load_include('inc', 'islandora_ocr', 'includes/derivatives');
-    islandora_ocr_set_generating_rels_ext_statements($object, !$config['ignored_derivs']['ocr'], !$config['ignored_derivs']['hocr']);
+    islandora_ocr_set_generating_rels_ext_statements($object, !$config['ignored_derivs']['ocr'], !$config['ignored_derivs']['hocr'], $config['language']);
   }
-  islandora_paged_content_set_relationship($rels_ext, ISLANDORA_RELS_EXT_URI, 'hasLanguage', $config['language'], TRUE);
   islandora_paged_content_set_relationship($rels_ext, ISLANDORA_RELS_EXT_URI, 'isPageOf', $parent);
   islandora_paged_content_set_relationship($rels_ext, ISLANDORA_RELS_EXT_URI, 'isSequenceNumber', (string) $config['page_number'], TRUE);
   islandora_paged_content_set_relationship($rels_ext, ISLANDORA_RELS_EXT_URI, 'isPageNumber', (string) $config['page_number'], TRUE);

--- a/includes/manage_pages.inc
+++ b/includes/manage_pages.inc
@@ -802,9 +802,7 @@ function islandora_paged_content_add_pages($repository, $config, $pages_director
   // somewhere other than the form.
   if (module_exists('islandora_ocr')) {
     module_load_include('inc', 'islandora_ocr', 'includes/derivatives');
-    $generate_ocr = isset($config['ignored_derivs']['ocr']) ? FALSE : NULL;
-    $generate_hocr = isset($config['ignored_derivs']['hocr']) ? FALSE : NULL;
-    islandora_ocr_set_generating_rels_ext_statements($object, $generate_ocr, $generate_hocr);
+    islandora_ocr_set_generating_rels_ext_statements($object, !$config['ignored_derivs']['ocr'], !$config['ignored_derivs']['hocr']);
   }
   islandora_paged_content_set_relationship($rels_ext, ISLANDORA_RELS_EXT_URI, 'hasLanguage', $config['language'], TRUE);
   islandora_paged_content_set_relationship($rels_ext, ISLANDORA_RELS_EXT_URI, 'isPageOf', $parent);

--- a/includes/upload_page.form.inc
+++ b/includes/upload_page.form.inc
@@ -67,7 +67,6 @@ function islandora_paged_content_upload_page_form(array $form, array &$form_stat
  *   The Drupal form state.
  */
 function islandora_paged_content_upload_page_form_submit(array $form, array &$form_state) {
-  dpm($form_state);
   module_load_include('inc', 'islandora_paged_content', 'includes/utilities');
   $object = islandora_ingest_form_get_object($form_state);
   $file = file_load($form_state['values']['file']);

--- a/includes/upload_page.form.inc
+++ b/includes/upload_page.form.inc
@@ -19,15 +19,18 @@
  *   An array containing the form to be rendered.
  */
 function islandora_paged_content_upload_page_form(array $form, array &$form_state, AbstractObject $parent) {
-  module_load_include('inc', 'islandora_ocr', 'includes/utilities');
   $get_default_value = function($name, $default) use(&$form_state) {
     return isset($form_state['values'][$name]) ? $form_state['values'][$name] : $default;
   };
   $form_state['parent'] = $parent;
   $upload_size = min((int) ini_get('post_max_size'), (int) ini_get('upload_max_filesize'));
   $extensions = array('tiff tif jp2 jpg jpeg');
-  $languages = module_exists('islandora_ocr') ? islandora_ocr_get_enabled_tesseract_languages() : array();
-  $default_language = in_array('English', $languages) ? 'eng' : NULL;
+  $languages = array();
+  if (module_exists('islandora_ocr')) {
+    module_load_include('inc', 'islandora_ocr', 'includes/utilities');
+    $languages = islandora_ocr_get_enabled_tesseract_languages();
+  }
+  $default_language = in_array('eng', $languages) ? 'eng' : NULL;
 
   $upload_form = array(
     'file' => array(

--- a/includes/upload_page.form.inc
+++ b/includes/upload_page.form.inc
@@ -83,11 +83,9 @@ function islandora_paged_content_upload_page_form_submit(array $form, array &$fo
   $object->label = $label;
 
   // Add the OCR creation flags before the datastream is updated.
-  if (isset($form_state['values']['ignore_ocr']) && $form_state['values']['ignore_ocr']) {
-    islandora_paged_content_set_relationship($rels_ext, ISLANDORA_RELS_EXT_URI, 'generate_ocr', 'FALSE', TRUE);
-  }
-  if (isset($form_state['values']['ignore_hocr']) && $form_state['values']['ignore_hocr']) {
-    islandora_paged_content_set_relationship($rels_ext, ISLANDORA_RELS_EXT_URI, 'generate_hocr', 'FALSE', TRUE);
+  if (module_exists('islandora_ocr')) {
+    module_load_include('inc', 'islandora_ocr', 'includes/derivatives');
+    islandora_ocr_set_generating_rels_ext_statements($object, !$form_state['values']['generate_ocr'], !$form_state['values']['generate_hocr']);
   }
   islandora_paged_content_update_datastream($object, drupal_realpath($file->uri), 'OBJ', NULL, NULL, 'M', FALSE);
   // Update RELS-EXT properties, page/sequence/etc, and append the page at the

--- a/includes/upload_page.form.inc
+++ b/includes/upload_page.form.inc
@@ -67,6 +67,7 @@ function islandora_paged_content_upload_page_form(array $form, array &$form_stat
  *   The Drupal form state.
  */
 function islandora_paged_content_upload_page_form_submit(array $form, array &$form_state) {
+  dpm($form_state);
   module_load_include('inc', 'islandora_paged_content', 'includes/utilities');
   $object = islandora_ingest_form_get_object($form_state);
   $file = file_load($form_state['values']['file']);
@@ -85,7 +86,7 @@ function islandora_paged_content_upload_page_form_submit(array $form, array &$fo
   // Add the OCR creation flags before the datastream is updated.
   if (module_exists('islandora_ocr')) {
     module_load_include('inc', 'islandora_ocr', 'includes/derivatives');
-    islandora_ocr_set_generating_rels_ext_statements($object, !$form_state['values']['generate_ocr'], !$form_state['values']['generate_hocr']);
+    islandora_ocr_set_generating_rels_ext_statements($object, !$form_state['values']['ignore_ocr'], !$form_state['values']['ignore_hocr']);
   }
   islandora_paged_content_update_datastream($object, drupal_realpath($file->uri), 'OBJ', NULL, NULL, 'M', FALSE);
   // Update RELS-EXT properties, page/sequence/etc, and append the page at the

--- a/includes/upload_page.form.inc
+++ b/includes/upload_page.form.inc
@@ -28,7 +28,7 @@ function islandora_paged_content_upload_page_form(array $form, array &$form_stat
   $extensions = array('tiff tif jp2 jpg jpeg');
   $languages = module_exists('islandora_ocr') ? islandora_ocr_get_enabled_tesseract_languages() : array();
 
-  return array(
+  $upload_form = array(
     'file' => array(
       '#title' => t('Page'),
       '#type' => 'managed_file',
@@ -41,16 +41,21 @@ function islandora_paged_content_upload_page_form(array $form, array &$form_stat
         'file_validate_size' => array($upload_size * 1024 * 1024),
       ),
     ),
+  );
 
-    'language' => array(
+  if (module_exists('islandora_ocr')) {
+    $upload_form['language'] = array(
       '#access' => module_exists('islandora_ocr'),
       '#title' => t('Language'),
       '#type' => 'select',
       '#description' => t('Please select the language the page is written in.'),
       '#options' => $languages,
       '#default_value' => $get_default_value('language', NULL),
-    ),
-  );
+    );
+    $upload_form['ocr_ignored_derivatives'] = islandora_ocr_get_ignored_derivatives_fieldset();
+  }
+
+  return $upload_form;
 }
 
 /**
@@ -68,6 +73,7 @@ function islandora_paged_content_upload_page_form_submit(array $form, array &$fo
   $parent = $form_state['parent'];
   $pages = islandora_paged_content_get_pages($parent);
   $num_pages = count($pages) + 1;
+  $rels_ext = $object->relationships;
 
   $label = $file->filename;
   // Change the label of the page to the sequence number if variable is set.
@@ -76,10 +82,16 @@ function islandora_paged_content_upload_page_form_submit(array $form, array &$fo
   }
   $object->label = $label;
 
+  // Add the OCR creation flags before the datastream is updated.
+  if (isset($form_state['values']['ignore_ocr']) && $form_state['values']['ignore_ocr']) {
+    islandora_paged_content_set_relationship($rels_ext, ISLANDORA_RELS_EXT_URI, 'generate_ocr', 'FALSE', TRUE);
+  }
+  if (isset($form_state['values']['ignore_hocr']) && $form_state['values']['ignore_hocr']) {
+    islandora_paged_content_set_relationship($rels_ext, ISLANDORA_RELS_EXT_URI, 'generate_hocr', 'FALSE', TRUE);
+  }
   islandora_paged_content_update_datastream($object, drupal_realpath($file->uri), 'OBJ', NULL, NULL, 'M', FALSE);
   // Update RELS-EXT properties, page/sequence/etc, and append the page at the
   // end of the book.
-  $rels_ext = $object->relationships;
   if (isset($form_state['values']['language'])) {
     islandora_paged_content_set_relationship($rels_ext, ISLANDORA_RELS_EXT_URI, 'hasLanguage', $form_state['values']['language'], TRUE);
   }

--- a/includes/upload_page.form.inc
+++ b/includes/upload_page.form.inc
@@ -27,6 +27,7 @@ function islandora_paged_content_upload_page_form(array $form, array &$form_stat
   $upload_size = min((int) ini_get('post_max_size'), (int) ini_get('upload_max_filesize'));
   $extensions = array('tiff tif jp2 jpg jpeg');
   $languages = module_exists('islandora_ocr') ? islandora_ocr_get_enabled_tesseract_languages() : array();
+  $default_language = in_array('English', $languages) ? 'eng' : NULL;
 
   $upload_form = array(
     'file' => array(
@@ -50,7 +51,7 @@ function islandora_paged_content_upload_page_form(array $form, array &$form_stat
       '#type' => 'select',
       '#description' => t('Please select the language the page is written in.'),
       '#options' => $languages,
-      '#default_value' => $get_default_value('language', NULL),
+      '#default_value' => $get_default_value('language', $default_language),
     );
     $upload_form['ocr_ignored_derivatives'] = islandora_ocr_get_ignored_derivatives_fieldset();
   }
@@ -85,15 +86,12 @@ function islandora_paged_content_upload_page_form_submit(array $form, array &$fo
   // Add the OCR creation flags before the datastream is updated.
   if (module_exists('islandora_ocr')) {
     module_load_include('inc', 'islandora_ocr', 'includes/derivatives');
-    islandora_ocr_set_generating_rels_ext_statements($object, !$form_state['values']['ignore_ocr'], !$form_state['values']['ignore_hocr']);
+    $language = isset($form_state['values']['language']) ? $form_state['values']['language'] : NULL;
+    islandora_ocr_set_generating_rels_ext_statements($object, !$form_state['values']['ignore_ocr'], !$form_state['values']['ignore_hocr'], $language);
   }
   islandora_paged_content_update_datastream($object, drupal_realpath($file->uri), 'OBJ', NULL, NULL, 'M', FALSE);
   // Update RELS-EXT properties, page/sequence/etc, and append the page at the
   // end of the book.
-  if (isset($form_state['values']['language'])) {
-    islandora_paged_content_set_relationship($rels_ext, ISLANDORA_RELS_EXT_URI, 'hasLanguage', $form_state['values']['language'], TRUE);
-  }
-
   islandora_paged_content_set_relationship($rels_ext, ISLANDORA_RELS_EXT_URI, 'isPageOf', $parent->id);
   islandora_paged_content_set_relationship($rels_ext, ISLANDORA_RELS_EXT_URI, 'isSequenceNumber', (string) $num_pages, TRUE);
   islandora_paged_content_set_relationship($rels_ext, ISLANDORA_RELS_EXT_URI, 'isPageNumber', (string) $num_pages, TRUE);

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -1303,6 +1303,7 @@ function islandora_paged_content_add_relationships_to_child(AbstractObject $obje
   islandora_paged_content_set_relationship($rels_ext, ISLANDORA_RELS_EXT_URI, 'isSection', '1', TRUE);
   if ($params['extract_text'] == 'none') {
     $object->relationships->add(ISLANDORA_RELS_EXT_URI, 'generate_ocr', 'FALSE', RELS_TYPE_PLAIN_LITERAL);
+    $object->relationships->add(ISLANDORA_RELS_EXT_URI, 'generate_hocr', 'FALSE', RELS_TYPE_PLAIN_LITERAL);
   }
   else {
     islandora_paged_content_set_relationship($rels_ext, ISLANDORA_RELS_EXT_URI, 'hasLanguage', $params['language'], TRUE);

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -1301,9 +1301,9 @@ function islandora_paged_content_add_relationships_to_child(AbstractObject $obje
   islandora_paged_content_set_relationship($rels_ext, ISLANDORA_RELS_EXT_URI, 'isSequenceNumber', $params['page_number'], TRUE);
   islandora_paged_content_set_relationship($rels_ext, ISLANDORA_RELS_EXT_URI, 'isPageNumber', $params['page_number'], TRUE);
   islandora_paged_content_set_relationship($rels_ext, ISLANDORA_RELS_EXT_URI, 'isSection', '1', TRUE);
-  if ($params['extract_text'] == 'none') {
-    $object->relationships->add(ISLANDORA_RELS_EXT_URI, 'generate_ocr', 'FALSE', RELS_TYPE_PLAIN_LITERAL);
-    $object->relationships->add(ISLANDORA_RELS_EXT_URI, 'generate_hocr', 'FALSE', RELS_TYPE_PLAIN_LITERAL);
+  if ($params['extract_text'] == 'none' && module_exists('islandora_ocr')) {
+    module_load_include('inc', 'islandora_ocr', 'includes/derivatives');
+    islandora_ocr_set_generating_rels_ext_statements($object, FALSE, FALSE);
   }
   else {
     islandora_paged_content_set_relationship($rels_ext, ISLANDORA_RELS_EXT_URI, 'hasLanguage', $params['language'], TRUE);

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -985,7 +985,7 @@ function islandora_paged_content_page_derivatives($context) {
     $derivatives[] = array(
       'source_dsid' => 'OBJ',
       'destination_dsid' => NULL,
-      'weight' => -1,
+      'weight' => 1,
       'function' => array('islandora_ocr_remove_generating_rels_ext_statements'),
       'file' => "$ocr_module_path/includes/derivatives.inc",
     );

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -982,6 +982,13 @@ function islandora_paged_content_page_derivatives($context) {
       'function' => array('islandora_ocr_derive_hocr'),
       'file' => "$ocr_module_path/includes/derivatives.inc",
     );
+    $derivatives[] = array(
+      'source_dsid' => NULL,
+      'destination_dsid' => NULL,
+      'weight' => -1,
+      'function' => array('islandora_ocr_remove_generating_rels_ext_statements'),
+      'file' => "$ocr_module_path/includes/derivatives.inc",
+    );
   }
   if (isset($derive['image']) && $derive['image']) {
     $derivatives[] = array(

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -983,7 +983,7 @@ function islandora_paged_content_page_derivatives($context) {
       'file' => "$ocr_module_path/includes/derivatives.inc",
     );
     $derivatives[] = array(
-      'source_dsid' => NULL,
+      'source_dsid' => 'OBJ',
       'destination_dsid' => NULL,
       'weight' => -1,
       'function' => array('islandora_ocr_remove_generating_rels_ext_statements'),


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2012

* Other Relevant Links hard-requirement relies upon https://github.com/Islandora/islandora_ocr/pull/81

# What does this Pull Request do?
Makes it so that during page management and page upload, individual OCR/HOCR derivatives can be ignored in cases where such is not desired.

# What's new?
OCR/HOCR opt-out options when uploading page(s).

# How should this be tested?
Ingest a page or a batch of zipped pages to a paged content object. Check off individual ignored OCR/HOCR derivatives. These derivatives should not be generated for the resultant page(s).

# Additional Notes:
I think the only place this specific zipped page upload is used is for newspaper ... book has its own.

# Interested parties
@jordandukart for maintainer funsies
