### PR TITLE
ISLANDORA-2026 - changed logic operator for file_get_contents call in…

### DIFF
--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -464,7 +464,9 @@ function islandora_paged_content_ocr_combine(array $files, $out) {
       $success = FALSE;
     }
     else {
-      $success = file_put_contents($out, $ocr, FILE_APPEND) == FALSE ? FALSE : $success;
+      if ($ocr) {
+        $success = file_put_contents($out, $ocr, FILE_APPEND) == FALSE ? FALSE : $success;
+      }
     }
   }
   return $success;

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -460,7 +460,7 @@ function islandora_paged_content_ocr_combine(array $files, $out) {
   $success = TRUE;
   foreach ($files as $file) {
     $ocr = file_get_contents($file);
-    if ($ocr == FALSE) {
+    if ($ocr === FALSE) {
       $success = FALSE;
     }
     else {


### PR DESCRIPTION
… islandora_paged_content_ocr_combine

**JIRA Ticket**: (link)
https://jira.duraspace.org/browse/ISLANDORA-2026

# What does this Pull Request do?
Updates the logic used with the result of file_get_contents - which needs to use "===" instead of "==".

A brief description of what the intended result of the PR will be and/or what problem it solves.
When the system attempts to aggregate paged content's OCR, it can fail when it comes upon an empty OCR file or even if the OCR for a given page is the character "0" since both would result in failure of OCR aggregation with "==", it needs to compare the type as well as the value in order to consider the file_get_contents as a failure.  Prior to this patch, the aggregate function could fail on books that contained an empty page or a picture that had no OCR.

# What's new?
A in-depth description of the changes made by this PR. Technical details and possible side effects.
This change is the addition of a single "=".

Example:
* Changes x feature to such that y
* Added x
* Removed y

# How should this be tested?
With a book that has at least one page that has an empty OCR file, attempt to aggregate OCR before applying this code patch, it would fail... apply this patch to the code and attempt to aggregate the OCR again and it should succeed.

A description of what steps someone could take to:
* Reproduce the problem you are fixing (if applicable)
* Test that the Pull Request does what is intended.
* Please be as detailed as possible.
* Good testing instructions help get your PR completed faster.
If you need to hack a test book object, simply replace any page's OCR datastream with an empty text file upload... that page's OCR datastream would read as 0 or -1 size in the manage/datastreams view.  Then, try to aggregate OCR for that book.  If the book does not get an aggregated OCR datatream, the code is exhibiting the bug I identify here.
