### PR TITLE
ISLANDORA-2133, adjusted sparql query to pull width and height from t…

### DIFF
--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -70,9 +70,15 @@ function islandora_paged_content_get_pages_ri(AbstractObject $object) {
     OPTIONAL {
       ?pid <fedora-view:disseminates> ?dss .
       ?dss <fedora-view:disseminationType> <info:fedora/*/JP2> ;
+           islandora-rels-ext:width ?width ;
+           islandora-rels-ext:height ?height .
+    }
+    OPTIONAL {
+      ?pid <fedora-view:disseminates> ?dss .
+      ?dss <fedora-view:disseminationType> <info:fedora/*/JP2> ;
            islandora-rels-int:width ?width ;
            islandora-rels-int:height ?height .
-   }
+    }
   }
   ORDER BY ?page
 EOQ;

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -59,6 +59,7 @@ function islandora_paged_content_get_pages(AbstractObject $object) {
 function islandora_paged_content_get_pages_ri(AbstractObject $object) {
   $query = <<<EOQ
   PREFIX islandora-rels-ext: <http://islandora.ca/ontology/relsext#>
+  PREFIX islandora-rels-int: <http://islandora.ca/ontology/relsint#>
   SELECT ?pid ?page ?label ?width ?height
   FROM <#ri>
   WHERE {
@@ -69,8 +70,8 @@ function islandora_paged_content_get_pages_ri(AbstractObject $object) {
     OPTIONAL {
       ?pid <fedora-view:disseminates> ?dss .
       ?dss <fedora-view:disseminationType> <info:fedora/*/JP2> ;
-           islandora-rels-ext:width ?width ;
-           islandora-rels-ext:height ?height .
+           islandora-rels-int:width ?width ;
+           islandora-rels-int:height ?height .
    }
   }
   ORDER BY ?page


### PR DESCRIPTION
…he rels-int

**JIRA Ticket**: (link)
https://jira.duraspace.org/browse/ISLANDORA-2133

The RI query should now bring back the width and height for the pages related to a given paged content object.

# What's new?
Since this fixes a bug, the only changes may be seen where the previous code was not supplying page dimensions and now they are.

Example:
* Changes x feature to such that y
* Added x
* Removed y

# How should this be tested?
In order to see the results of the code, the site must have islandora_solr and the islandora_internet_archive_bookreader installed.
To observe the page values being supplied to the bookreader (with width and height), enable the option for "Use Solr to derive pages and sequence numbers" which allows Solr to populate the pages.  Review the HTML for a paged content object in the bookreader -- and notice a <script> block that contains all of the variables that are supplied to the bookreader (islandora_bookreader.js) script.  This should contain something like ..., pages:[{'pid':'xyz:10002', 'label':'page 1', 'width':2142, 'height':3408}, ...].

Now, disable the setting that allowed Solr to provide these values - and reload the bookreader page.  Ensure that the pages have values for width and height as before.



A description of what steps someone could take to:
* Reproduce the problem you are fixing (if applicable) -- if the site was configured to not use Solr, the bookreader code would fall back to an RI query - and this problem could be seen in a bookreader rendering (but not all the time).
* Test that the Pull Request does what is intended.
The method of viewing the HTML of a paged content object with a bookreader page may be more desirable to test this.  The easiest way to test that this is doing what it is supposed to do, is to add dpm($pages) to the islandora_paged_content_get_pages_ri itself after each attempt it makes to populate $pages.  If the query works, each set of page arrays should have the following keys 'pid', 'page', 'label', 'width', 'height'.


# Additional Notes:
Any additional information that you think would be helpful when reviewing this PR.

* Could this change impact execution of existing code?
I suppose that it could.  This is an extremely old bug, so there is a great chance that something used this function call and may not expect width & height - and suddenly the return will have this, or the code EXPECTED this call to return width & height all along, but enacted some sort of graceful failure for pages lacking width & height that may need to be changed.  In both of those cases, it may be good to blast out to the community that this function's fix could change the flow of any code that handles the results from calling the previous broken version of this function.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/7-x-1-x-committers
