### PR TITLE
Fix batch query and add some documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,15 @@ Otherwise, the book object will not receive an OCR datastream, and will not be r
 
 Further documentation for this module is available at [our wiki](https://wiki.duraspace.org/display/ISLANDORA/Islandora+Paged+Content).
 
+### Drush scripts
+
+`paged-content-consolidate-missing-ocr`
+
+This drush command finds all page objects whose parent does not have a 
+OCR datastream, generates it by combining the OCR datastreams from the children
+and adds that datastream to the parent.
+
+
 ## Troubleshooting/Issues
 
 Having problems or solved a problem? Check out the Islandora google groups for a solution.

--- a/includes/batch.inc
+++ b/includes/batch.inc
@@ -674,15 +674,18 @@ function islandora_paged_content_get_missing_ocr_paged_content_objects() {
   // Base query.
   $query = <<<EOQ
 PREFIX islandora-rels-ext: <http://islandora.ca/ontology/relsext#>
+PREFIX fedora-model: <info:fedora/fedora-system:def/model#>
+PREFIX fedora-view: <info:fedora/fedora-system:def/view#>
 SELECT DISTINCT ?pid
 FROM <#ri>
 WHERE {
-  ?page islandora-rels-ext:isPageOf ?pid
+  ?page islandora-rels-ext:isPageOf ?pid .
+  ?pid fedora-model:label ?label .
   OPTIONAL {
-    ?ds <fedora-view:disseminationType> <info:fedora/*/OCR> .
-    ?pid <info:fedora/fedora-system:def/view#disseminates> ?ds
+    ?ds fedora-view:disseminationType <info:fedora/*/OCR> .
+    ?pid fedora-view:disseminates ?ds .
   }
-  FILTER(!BOUND(?ds))
+  FILTER(!BOUND(?ds) && BOUND(?label))
 }
 EOQ;
 


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2139

# What does this Pull Request do?

The query used by the included drush script fails if it encounters an orphaned object. This changes the query to exclude orphans from the result.

# What's new?

Another FILTER in the Sparql query

# How should this be tested?

Ingest a newspaper or book object. Make sure the parent object (the newspaper issue or book object) does **not** have an OCR datastream (if it does delete it from the manage tab).

Get the PID of one of the pages of the book or newspaper.

Using the Fedora Admin (http://localhost:8080/fedora/admin) load the page object and edit the RELS-EXT datastream.

Change the below lines from whatever rdf:resource they had to the following.
```
<fedora:isMemberOf rdf:resource="info:fedora/fake:12"/>
<islandora:isPageOf rdf:resource="info:fedora/fake:12"/> 
```

As long as that isn't a valid PID. Then **Save Changes**.

Now if you run the script
```
drush -u 1 -v pccmo
```

You should get an error like
```
Argument 1 passed to islandora_paged_content_get_pages() must be an instance of AbstractObject, boolean given, called in                [notice]
/var/www/drupal/sites/all/modules/islandora_paged_content/includes/batch.inc on line 643 and defined utilities.inc:23
Argument 1 passed to islandora_paged_content_get_pages_ri() must be an instance of AbstractObject, boolean given, called in             [notice]
/var/www/drupal/sites/all/modules/islandora_paged_content/includes/utilities.inc on line 34 and defined utilities.inc:59
Trying to get property of non-object utilities.inc:65                                                                                   [notice]
Trying to get property of non-object utilities.inc:79                                                                                   [notice]
Trying to get property of non-object utilities.inc:79                                                                                   [notice]
PHP Fatal error:  Call to a member function sparqlQuery() on a non-object in /var/www/drupal/sites/all/modules/islandora_paged_content/includes/utilities.inc on line 79
PHP Stack trace:
PHP   1. {main}() /opt/drush-6.3/drush.php:0
PHP   2. drush_main() /opt/drush-6.3/drush.php:16
PHP   3. _drush_bootstrap_and_dispatch() /opt/drush-6.3/drush.php:61
PHP   4. drush_dispatch() /opt/drush-6.3/drush.php:92
PHP   5. call_user_func_array() /opt/drush-6.3/includes/command.inc:182
PHP   6. drush_command() /opt/drush-6.3/includes/command.inc:182
PHP   7. _drush_invoke_hooks() /opt/drush-6.3/includes/command.inc:214
PHP   8. call_user_func_array() /opt/drush-6.3/includes/command.inc:362
PHP   9. drush_core_batch_process() /opt/drush-6.3/includes/command.inc:362
PHP  10. drush_batch_command() /opt/drush-6.3/commands/core/core.drush.inc:1145
PHP  11. _drush_batch_command() /opt/drush-6.3/includes/batch.inc:93
Drush command terminated abnormally due to an unrecoverable error.                                                                   [error]
Error: Call to a member function sparqlQuery() on a non-object in
/var/www/drupal/sites/all/modules/islandora_paged_content/includes/utilities.inc, line 79
PHP  12. _drush_batch_worker() /opt/drush-6.3/commands/core/drupal/batch.inc:99
PHP  13. call_user_func_array() /opt/drush-6.3/commands/core/drupal/batch.inc:149
PHP  14. islandora_paged_content_consolidate_missing_ocr_batch_operation() /opt/drush-6.3/commands/core/drupal/batch.inc:149
PHP  15. islandora_paged_content_get_pages() /var/www/drupal/sites/all/modules/islandora_paged_content/includes/batch.inc:643
PHP  16. islandora_paged_content_get_pages_ri() /var/www/drupal/sites/all/modules/islandora_paged_content/includes/utilities.inc:34
The external command could not be executed due to an application error.                                                              [error]
Command dispatch complete
```

Pull in this PR and rerun the above command. It should complete successfully and your book/newspaper object should have an OCR datastream added.

# Additional Notes:

Example:
* Does this change require documentation to be updated? Added some documentation of this drush command
* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# Interested parties
@bondjimbond 
