### PR TITLE
query stuff

### DIFF
--- a/includes/batch.inc
+++ b/includes/batch.inc
@@ -674,18 +674,17 @@ function islandora_paged_content_get_missing_ocr_paged_content_objects() {
   // Base query.
   $query = <<<EOQ
 PREFIX islandora-rels-ext: <http://islandora.ca/ontology/relsext#>
-PREFIX fedora-model: <info:fedora/fedora-system:def/model#>
 PREFIX fedora-view: <info:fedora/fedora-system:def/view#>
 SELECT DISTINCT ?pid
 FROM <#ri>
 WHERE {
   ?page islandora-rels-ext:isPageOf ?pid .
-  ?pid fedora-model:label ?label .
+  ?pid fedora-view:lastModifiedDate ?date .
   OPTIONAL {
     ?ds fedora-view:disseminationType <info:fedora/*/OCR> .
     ?pid fedora-view:disseminates ?ds .
   }
-  FILTER(!BOUND(?ds) && BOUND(?label))
+  FILTER(!BOUND(?ds))
 }
 EOQ;
 

--- a/includes/batch.inc
+++ b/includes/batch.inc
@@ -675,11 +675,12 @@ function islandora_paged_content_get_missing_ocr_paged_content_objects() {
   $query = <<<EOQ
 PREFIX islandora-rels-ext: <http://islandora.ca/ontology/relsext#>
 PREFIX fedora-view: <info:fedora/fedora-system:def/view#>
+PREFIX fedora-model: <info:fedora/fedora-system:def/model#>
 SELECT DISTINCT ?pid
 FROM <#ri>
 WHERE {
   ?page islandora-rels-ext:isPageOf ?pid .
-  ?pid fedora-view:lastModifiedDate ?date .
+  ?pid fedora-model:hasModel <info:fedora/fedora-system:FedoraObject-3.0> .
   OPTIONAL {
     ?ds fedora-view:disseminationType <info:fedora/*/OCR> .
     ?pid fedora-view:disseminates ?ds .


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2143

* Relates to https://github.com/Islandora/islandora_paged_content/pull/141/files

# What does this Pull Request do?
Two small changes to the consolidate OCR query for paged content objects detailed below

# What's new?
Changes to the pccmo query:

* Moving the attempt to bind 'label' to the graph to an attempt to bind 'lastModifiedDate' to match in-practice cardinality of Fedora properties, as label can be not set (in contrast with the documentation's claim that it always will be).
* Removing the bound check for the property as it will always be bound to the graph

# How should this be tested?
* Create a book object
* Remove the consolidated OCR datastream from it (or just don't create it)
* Remove the label from the book object
  * Easiest is probably through the Fedora admin interface; open the object, delete the label from the textbox, and commit changes
  * Alternatively, you could pair the book with a MODS XML file that contains an empty `<titleInfo><title/></titleInfo>` element
* Run `drush -v -u 1 pccmo`

*Before*: OCR will not be consolidated on the book, as it will not be found
*After*: OCR will be consolidated on the book

# Interested parties
@whikloj and @bondjimbond from the original PR
