### PR TITLE
ISLANDORA-22016: fixes wrong type in function's signature argument

### DIFF
--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -451,7 +451,7 @@ function islandora_paged_content_can_combine_pdf() {
 }
 
 /**
- * Appends onto a given PDF file a number of PDF filese
+ * Appends onto a given PDF file a number of PDF files.
  *
  * @param string $file
  *   The absolute path of the PDF file to append onto.

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -451,17 +451,17 @@ function islandora_paged_content_can_combine_pdf() {
 }
 
 /**
- * Appends a number of PDF files onto the given PDF file.
+ * Appends onto a given PDF file a number of PDF filese
  *
- * @param array $file
- *   The PDF files to append onto.
+ * @param string $file
+ *   The absolute path of the PDF file to append onto.
  * @param array $files
  *   The PDF files to append.
  *
  * @return bool
  *   TRUE if successful, FALSE otherwise.
  */
-function islandora_paged_content_pdf_append(array $file, array $files) {
+function islandora_paged_content_pdf_append($file, array $files) {
   $temp_file = "$file.temp.pdf";
   copy($file, $temp_file);
   array_unshift($files, $temp_file);


### PR DESCRIPTION
**JIRA Ticket**: (https://jira.duraspace.org/browse/ISLANDORA-2206)

# What does this Pull Request do?

Fixes an issue with a wrongly declared PHPDoc that forced a wrongly declared function signature's argument type. This wrongly introduced condition made PDF combining during batch fail in book SP.

# What's new?
Functionally nothing, back to ingesting Books and PDF. Just correct PHPDoc

# How should this be tested?

See https://jira.duraspace.org/browse/ISLANDORA-2206

# Additional Notes:

This bug was introduced because DCS require argument types of functions to match their declared PHPDoc types (array in this case). But functionality was using string instead (a file path)


* Does this change require documentation to be updated? 
No
* Does this change add any new dependencies? 
No
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? 
No? If you ingested recently a book and wanted the PDF to be combined this would have failed badly with the same notice documented in the JIRA ticket
* Could this change impact execution of existing code?
No

# Interested parties
@bondjimbond @rosiel 