### PR TITLE
302 then 200 is success

### DIFF
--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -234,7 +234,14 @@ function islandora_paged_content_admin_settings_form_gs_ajax_callback(array $for
  */
 function islandora_paged_content_admin_settings_form_djatoka_availible_message($djatoka_url) {
   $file_headers = @get_headers($djatoka_url);
-  $djatoka_availible = strstr($file_headers[0], '200') !== FALSE;
+  $djatoka_availible = FALSE;
+  foreach ($file_headers as $file_header) {
+    if (strstr($file_header, '200') !== FALSE) {
+      $djatoka_availible = TRUE;
+      break;
+    }
+  }
+//  $djatoka_availible = strstr($file_headers[0], '200') !== FALSE;
   if ($djatoka_availible) {
     $image = theme_image(array('path' => 'misc/watchdog-ok.png', 'attributes' => array()));
     $message = t('djatoka url is valid.');


### PR DESCRIPTION
The base code checks if the first response from the /adore-djatoka/ request is a 200.  In our box, there is a 302 redirect then a 200 success.  The base code considers this a fail.  To fix this, the new code loops through the response header for any 200.  

There may be an edge case I can't think of, where a 200 is returned from the adore-djatoka request -- when the url is not actually valid.  In which case, the new pull request would be harmful.
