### PR TITLE
Allow with or without info:fedora/ prefix

### DIFF
--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -116,9 +116,9 @@ EOQ;
 function islandora_paged_content_get_pages_solr(AbstractObject $object) {
   $pages = array();
   $qp = new islandoraSolrQueryProcessor();
-  $qp->buildQuery(format_string('@field:("@pid" OR "info:fedora/@pid")', array(
-    '@field' => variable_get('islandora_solr_member_of_field', 'RELS_EXT_isMemberOf_uri_ms'),
-    '@pid' => $object->id,
+  $qp->buildQuery(format_string('!field:("!pid" OR "info:fedora/!pid")', array(
+    '!field' => variable_get('islandora_solr_member_of_field', 'RELS_EXT_isMemberOf_uri_ms'),
+    '!pid' => $object->id,
   )
   ));
   $label_field = variable_get('islandora_solr_object_label_field', 'fgs_label_s');

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -116,9 +116,9 @@ EOQ;
 function islandora_paged_content_get_pages_solr(AbstractObject $object) {
   $pages = array();
   $qp = new islandoraSolrQueryProcessor();
-  $qp->buildQuery(format_string('@field:"@pid"', array(
+  $qp->buildQuery(format_string('@field:("@pid" OR "info:fedora/@pid")', array(
     '@field' => variable_get('islandora_solr_member_of_field', 'RELS_EXT_isMemberOf_uri_ms'),
-    '@pid' => "info:fedora/{$object->id}",
+    '@pid' => $object->id,
   )
   ));
   $label_field = variable_get('islandora_solr_object_label_field', 'fgs_label_s');


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2216

* Other Relevant Links (Google Groups discussion, related pull requests, Release pull requests, etc.)

# What does this Pull Request do?

Allows the isMemberOf solr field used when collecting the pages of an object to **not** have the _info:fedora/_ prefix.

# How should this be tested?

1. Create a small book where the objects have their RELS_EXT_isMemberOf_uri_* indexed without "info:fedora/" on the front.
1. Use Solr for paged content. 
1. See how there are no pages to your book. 😢 
1. Pull down this PR and reload your book.
1. Much happy, super fun 😃 

# Additional Notes:

Example:
* Does this change require documentation to be updated? no
* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# Interested parties
@Islandora/7-x-1-x-committers
