### PR TITLE
redirect then 200 is success

### DIFF
--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -26,7 +26,7 @@ function islandora_paged_content_admin_settings_form(array $form, array &$form_s
   $pdftotext = $get_default_value('islandora_paged_content_pdftotext', '/usr/bin/pdftotext');
 
   $djatoka_url = $get_default_value('islandora_paged_content_djatoka_url', 'http://localhost:8080/adore-djatoka/');
-  $djatoka_availible_message = islandora_paged_content_admin_settings_form_djatoka_availible_message($djatoka_url);
+  $djatoka_available_message = islandora_paged_content_admin_settings_form_djatoka_available_message($djatoka_url);
   $solr_enabled = module_exists('islandora_solr');
 
   $form = array(
@@ -100,7 +100,7 @@ function islandora_paged_content_admin_settings_form(array $form, array &$form_s
       '#prefix' => '<div id="djatoka-path-wrapper">',
       '#suffix' => '</div>',
       '#title' => t('djatoka URL'),
-      '#description' => filter_xss(t('<strong>Externally accessible</strong> URL to the djatoka instance.<br/>!msg', array('!msg' => $djatoka_availible_message))),
+      '#description' => filter_xss(t('<strong>Externally accessible</strong> URL to the djatoka instance.<br/>!msg', array('!msg' => $djatoka_available_message))),
       '#default_value' => $djatoka_url,
       '#ajax' => array(
         'callback' => 'islandora_paged_content_admin_settings_form_djatoka_ajax_callback',
@@ -232,10 +232,16 @@ function islandora_paged_content_admin_settings_form_gs_ajax_callback(array $for
  * @return string
  *   A message in html detailing if the djatoka is accessible.
  */
-function islandora_paged_content_admin_settings_form_djatoka_availible_message($djatoka_url) {
+function islandora_paged_content_admin_settings_form_djatoka_available_message($djatoka_url) {
   $file_headers = @get_headers($djatoka_url);
-  $djatoka_availible = strstr($file_headers[0], '200') !== FALSE;
-  if ($djatoka_availible) {
+  $djatoka_available = FALSE;
+  foreach ($file_headers as $file_header) {
+    if (strpos($file_header, '200') !== FALSE) {
+      $djatoka_available = TRUE;
+      break;
+    }
+  }
+  if ($djatoka_available) {
     $image = theme_image(array('path' => 'misc/watchdog-ok.png', 'attributes' => array()));
     $message = t('djatoka url is valid.');
   }


### PR DESCRIPTION
Continuing pull request from https://github.com/Islandora/islandora_paged_content/pull/147

New changes:  "availible" --> "available"
                         strpos instead of strstr, for needle/haystack
                         removed commented-out code

Old changes:  allows 302 redirect then a 200 to pass as a success.  See above link for more info