### PR TITLE
Don't filter out pages when retrieving pages.

### DIFF
--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -121,6 +121,10 @@ function islandora_paged_content_get_pages_solr(AbstractObject $object) {
     '@pid' => "info:fedora/{$object->id}",
   )
   ));
+  if (variable_get('islandora_paged_content_hide_pages_solr', FALSE)) {
+    $fq_to_remove = array(variable_get('islandora_paged_content_solr_fq', '-RELS_EXT_isPageOf_uri_ms:[* TO *]'));
+    $qp->solrParams['fq'] = array_diff($qp->solrParams['fq'], $fq_to_remove);
+  }
   $label_field = variable_get('islandora_solr_object_label_field', 'fgs_label_s');
   $sequence_field = variable_get('islandora_paged_content_sequence_number_field', 'RELS_EXT_isSequenceNumber_literal_ms');
   $height_field = variable_get('islandora_paged_content_solr_height_field', 'RELS_INT_height_literal_s');

--- a/tests/scripts/poppler-utils-install.sh
+++ b/tests/scripts/poppler-utils-install.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 
+apt-get update
 apt-get install poppler-utils


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2190

* Other Relevant Links (Google Groups discussion, related pull requests, Release pull requests, etc.)
Introduced/oversight in https://jira.duraspace.org/browse/ISLANDORA-1607

# What does this Pull Request do?
Page retrieval still happens from Solr even if they are filtered out of search result display.

# What's new?
Fixes the bug described above.

# How should this be tested?

Ingest a book.
Go to /admin/islandora/solution_pack_config/paged_content
Toggle "Use Solr to derive pages and sequence numbers".
 Toggle "Hide Page Objects From Search Results" 
Go to admin/islandora/search/islandora_solr/settings and under "Other" toggle "Debug mode" on.
View a book.
One of the debug links should point to a Solr query containing a query string of: "RELS_EXT_isMemberOf_uri_ms:"info:fedora/whateverpidofthebook"
NOTE that the query generated includes a fq of: "-RELS_EXT_isPageOf_uri_ms:[* TO *]"
Pull the code, note that that FQ is no longer present when it's ran again on the book view and results are returned for the pages. 

# Interested parties
@Islandora/7-x-1-x-committers as @willtp87 is the maintainer.
