### PR TITLE
Re-use existing function instead of repeating ourselves.

### DIFF
--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -176,6 +176,26 @@ function islandora_paged_content_admin_settings_form(array $form, array &$form_s
 }
 
 /**
+ * Gets a message to display if the ocr program provided is accessible or not.
+ * DEPRECATED: This function is a duplicate of
+ * islandora_executable_available_message().
+ *
+ * @param string $path
+ *   The path to an executable to check for availability.
+ * @param string $version
+ *   The version of exectuable.
+ *
+ * @return string
+ *   A message in html detailing if the given executable is accessible.
+ */
+function islandora_paged_content_admin_settings_form_executable_available_message($path, $version = NULL, $required_version = NULL) {
+  $message = islandora_deprecated('7.x-1.13', t('Please use islandora_executable_available_message() instead.'));
+  trigger_error(filter_xss($message), E_USER_DEPRECATED);
+
+  return islandora_executable_available_message($path, $version, $required_version);
+}
+
+/**
  * Ajax callback for the GS textfield.
  *
  * @param array $form

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -190,6 +190,7 @@ function islandora_paged_content_admin_settings_form(array $form, array &$form_s
  *   A message in html detailing if the given executable is accessible.
  */
 function islandora_paged_content_admin_settings_form_executable_available_message($path, $version = NULL, $required_version = NULL) {
+  module_load_include('inc', 'islandora', 'includes/utilities');
   $message = islandora_deprecated('7.x-1.13', t('Please use islandora_executable_available_message() instead.'));
   trigger_error(filter_xss($message), E_USER_DEPRECATED);
 

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -18,7 +18,7 @@
  */
 function islandora_paged_content_admin_settings_form(array $form, array &$form_state) {
   form_load_include($form_state, 'inc', 'islandora_paged_content', 'includes/admin.form');
-  module_load_include('inc', 'islandora', '/includes/utilities');
+  form_load_include($form_state, 'inc', 'islandora', 'includes/utilities');
   $get_default_value = function($name, $default) use(&$form_state) {
     return isset($form_state['values'][$name]) ? $form_state['values'][$name] : variable_get($name, $default);
   };

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -18,6 +18,7 @@
  */
 function islandora_paged_content_admin_settings_form(array $form, array &$form_state) {
   form_load_include($form_state, 'inc', 'islandora_paged_content', 'includes/admin.form');
+  module_load_include('inc','islandora','/includes/utilities');
   $get_default_value = function($name, $default) use(&$form_state) {
     return isset($form_state['values'][$name]) ? $form_state['values'][$name] : variable_get($name, $default);
   };
@@ -37,7 +38,7 @@ function islandora_paged_content_admin_settings_form(array $form, array &$form_s
         '#type' => 'textfield',
         '#title' => t('gs (GhostScript)'),
         '#description' => t('GhostScript is used to combine PDF files into a representation of a book or newspaper.<br/>!msg',
-                        array('!msg' => islandora_paged_content_admin_settings_form_executable_available_message($gs))),
+                        array('!msg' => islandora_executable_available_message($gs))),
         '#default_value' => $gs,
         '#prefix' => '<div id="gs-wrapper">',
         '#suffix' => '</div>',
@@ -57,7 +58,7 @@ function islandora_paged_content_admin_settings_form(array $form, array &$form_s
         '#title' => t('pdfinfo'),
         '#description' => t('Pdfinfo is used to extract information needed when ingesting a single PDF into paged content and individual page objects.<br/>!msg',
           array(
-            '!msg' => islandora_paged_content_admin_settings_form_executable_available_message($pdfinfo),
+            '!msg' => islandora_executable_available_message($pdfinfo),
           )
         ),
         '#default_value' => $pdfinfo,
@@ -75,7 +76,7 @@ function islandora_paged_content_admin_settings_form(array $form, array &$form_s
         '#title' => t('pdftotext'),
         '#description' => t('Pdftotext is used to extract text for OCR when ingesting a single PDF into paged content and individual page objects.<br/>!msg',
           array(
-            '!msg' => islandora_paged_content_admin_settings_form_executable_available_message($pdftotext),
+            '!msg' => islandora_executable_available_message($pdftotext),
           )
         ),
         '#default_value' => $pdftotext,
@@ -172,39 +173,6 @@ function islandora_paged_content_admin_settings_form(array $form, array &$form_s
     ),
   );
   return system_settings_form($form);
-}
-
-/**
- * Gets a message to display if the ocr program provided is accessible or not.
- *
- * @param string $path
- *   The path to an executable to check for availability.
- * @param string $version
- *   The version of exectuable.
- *
- * @return string
- *   A message in html detailing if the given executable is accessible.
- */
-function islandora_paged_content_admin_settings_form_executable_available_message($path, $version = NULL, $required_version = NULL) {
-  $available = is_executable($path);
-  if ($available) {
-    $image = theme_image(array('path' => 'misc/watchdog-ok.png', 'attributes' => array()));
-    $message = t('Executable found at @path', array('@path' => $path));
-    if ($version) {
-      $message .= t('<br/>Version: @version', array('@version' => $version));
-    }
-    if ($required_version) {
-      $message .= t('<br/>Required Version: @version', array('@version' => $required_version));
-      if (version_compare($version, $required_version) < 0) {
-        $image = theme_image(array('path' => 'misc/watchdog-error.png', 'attributes' => array()));
-      }
-    }
-  }
-  else {
-    $image = theme_image(array('path' => 'misc/watchdog-error.png', 'attributes' => array()));
-    $message = t('Unable to locate executable at @path', array('@path' => $path));
-  }
-  return $image . $message;
 }
 
 /**

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -18,7 +18,7 @@
  */
 function islandora_paged_content_admin_settings_form(array $form, array &$form_state) {
   form_load_include($form_state, 'inc', 'islandora_paged_content', 'includes/admin.form');
-  module_load_include('inc','islandora','/includes/utilities');
+  module_load_include('inc', 'islandora', '/includes/utilities');
   $get_default_value = function($name, $default) use(&$form_state) {
     return isset($form_state['values'][$name]) ? $form_state['values'][$name] : variable_get($name, $default);
   };
@@ -177,6 +177,7 @@ function islandora_paged_content_admin_settings_form(array $form, array &$form_s
 
 /**
  * Gets a message to display if the ocr program provided is accessible or not.
+ *
  * DEPRECATED: This function is a duplicate of
  * islandora_executable_available_message().
  *


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2300

* Sort of related: https://jira.duraspace.org/browse/ISLANDORA-1999 

# What does this Pull Request do?

Uses a function in core instead of defining a new one for this module. The two are letter-for-letter identical. 

# What's new?
Gets rid of islandora_paged_content_admin_settings_form_executable_available_message()
(ok, gently sends it into that goodnight for 7.x-1.13.)

# How should this be tested?

Test in the paged content admin form (Solution Pack Configuration > Paged Content Module) that a full executable path works (gives you the yay message), while a command (e.g. `gs` or a path that doesn't exist) returns the Nope message.


# Additional Notes:

* Does this change require documentation to be updated?  Nope
* Does this change add any new dependencies?  Nope - Islandora's already a dependency
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)?  Nope
* Could this change impact execution of existing code? **Nope - deprecated gently.**

# Interested parties
Unsure. @Islandora/7-x-1-x-committers
