### PR TITLE
Fix admin warning from djatoka URL field

### DIFF
--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -225,10 +225,12 @@ function islandora_paged_content_admin_settings_form_gs_ajax_callback(array $for
 function islandora_paged_content_admin_settings_form_djatoka_available_message($djatoka_url) {
   $file_headers = @get_headers($djatoka_url);
   $djatoka_available = FALSE;
-  foreach ($file_headers as $file_header) {
-    if (strpos($file_header, '200') !== FALSE) {
-      $djatoka_available = TRUE;
-      break;
+  if ($file_headers) {
+    foreach ($file_headers as $file_header) {
+      if (strpos($file_header, '200') !== FALSE) {
+        $djatoka_available = TRUE;
+        break;
+      }
     }
   }
   if ($djatoka_available) {


### PR DESCRIPTION


**JIRA Ticket**: [ISLANDORA-2361](https://jira.duraspace.org/browse/ISLANDORA-2361)

* Other Relevant Links (Google Groups discussion, related pull requests, Release pull requests, etc.)

# What does this Pull Request do?

Gets rid of admin warning message by tweaking the way that the djatoka endpoint given in the admin form is checked for validity.

# What's new?
Accounts for the possibility of [get_headers](http://php.net/manual/en/function.get-headers.php) to return `FALSE` on failure (namely from a bad URL like a blank string or gibberish). Checks for truthiness of `file_headers` before looping.

# How should this be tested?

To reproduce warning:
* Navigate to solution pack admin -> paged content module.
* Leave djatoka URL blank
* Verify that warning message appears:
`Warning: Invalid argument supplied for foreach() in islandora_paged_content_admin_settings_form_djatoka_available_message() (line 228 of /var/www/drupal7/sites/all/modules/islandora_paged_content/includes/admin.form.inc).`

After pulling in changes in this PR, follow above steps and verify warning message does not appear. Verify that djatoka URL admin field still denotes "Unable to locate djatoka installation`

# Interested parties
@rosiel 
