### PR TITLE
Make maintainer match component manager in 7.x-1.13 release sheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Having problems or solved a problem? Check out the Islandora google groups for a
 
 Current maintainers:
 
-* [Rosie Le Faive](https://github.com/rosiel)
+* [Jared Whiklo](https://github.com/whikloj)
 
 ## Development
 


### PR DESCRIPTION

* Other Relevant Links (Google Groups discussion, related pull requests, Release pull requests, etc.)
    7.x-1.13 Release team Spreadsheet

# What does this Pull Request do?
Update to Readme to make @whikloj  the maintainer for the next release

# How should this be tested?

Check the readme against the spreadsheet to make sure that the listed Maintainer matches the entry in the Component Manager field.

# Interested parties
@Islandora/7-x-1-x-committers
