### PR TITLE
Centralize Image server settings to Core.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Install as usual, see [this](https://drupal.org/documentation/install/modules-th
 
 ## Configuration
 
-Set the path for `gs` (GhostScript), the externally accessible Djatoka URL, and the 'Solr page sequence number field' in Administration » Islandora » Solution pack configuration » Paged Content Module (admin/islandora/solution_pack_config/paged_content).
+Set the path for `gs` (GhostScript), and the 'Solr page sequence number field' in Administration » Islandora » Solution pack configuration » Paged Content Module (admin/islandora/solution_pack_config/paged_content).
 
 ![Configuration](https://user-images.githubusercontent.com/2857697/39014759-e2ef9c1e-43e0-11e8-921c-c2a3234d65d2.jpg)
 

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -19,18 +19,30 @@
 function islandora_paged_content_admin_settings_form(array $form, array &$form_state) {
   form_load_include($form_state, 'inc', 'islandora_paged_content', 'includes/admin.form');
   form_load_include($form_state, 'inc', 'islandora', 'includes/utilities');
+  form_load_include($form_state, 'inc', 'islandora', 'includes/imageserver');
   $get_default_value = function($name, $default) use(&$form_state) {
     return isset($form_state['values'][$name]) ? $form_state['values'][$name] : variable_get($name, $default);
   };
   $gs = $get_default_value('islandora_paged_content_gs', '/usr/bin/gs');
   $pdfinfo = $get_default_value('islandora_paged_content_pdfinfo', '/usr/bin/pdfinfo');
   $pdftotext = $get_default_value('islandora_paged_content_pdftotext', '/usr/bin/pdftotext');
+  $imageserver_settings = islandora_imageserver_get_settings();
 
-  $djatoka_url = $get_default_value('islandora_paged_content_djatoka_url', 'http://localhost:8080/adore-djatoka/');
-  $djatoka_available_message = islandora_paged_content_admin_settings_form_djatoka_available_message($djatoka_url);
   $solr_enabled = module_exists('islandora_solr');
 
   $form = array(
+    'islandora_paged_content_tilesource' => array(
+      '#type' => 'select',
+      '#title' => t('Image Server'),
+      '#description' => t('The image server to use, configure at Admin -> Islandora -> Image server configuration'),
+      '#default_value' => $imageserver_settings['type'],
+      '#disabled' => TRUE,
+      '#options' => array(
+        'none' => t('No image server configured'),
+        'iiif' => t('IIIF image server'),
+        'djatoka' => t('Adore-Djatoka image server'),
+      ),
+    ),
     'pdf_derivative_settings' => array(
       '#type' => 'fieldset',
       '#title' => t('PDF Derivative Settings'),
@@ -94,20 +106,6 @@ function islandora_paged_content_admin_settings_form(array $form, array &$form_s
         '#title' => t('Allow Extraction of Raw Text'),
         '#description' => t('This will pass the -raw parameter off to pdftotext when extracting text. By default, pdftotext extracts text in natural reading order. In edge case documents, where PDF creation tools have made blocks in errorneous order, text extraction will yield unexpected results. As such, this parameter will pull out text in the order that the PDF creation tool wrote it (layout ignored). This is not a valid default option to have due to that PDF creation tools are not constrained to writing blocks in the order they appear and it is up to the PDF reader to render them correctly.'),
         '#default_value' => variable_get('islandora_paged_content_pdftotext_use_raw', FALSE),
-      ),
-    ),
-    'islandora_paged_content_djatoka_url' => array(
-      '#type' => 'textfield',
-      '#prefix' => '<div id="djatoka-path-wrapper">',
-      '#suffix' => '</div>',
-      '#title' => t('djatoka URL'),
-      '#description' => filter_xss(t('<strong>Externally accessible</strong> URL to the djatoka instance.<br/>!msg', array('!msg' => $djatoka_available_message))),
-      '#default_value' => $djatoka_url,
-      '#ajax' => array(
-        'callback' => 'islandora_paged_content_admin_settings_form_djatoka_ajax_callback',
-        'wrapper' => 'djatoka-path-wrapper',
-        'effect' => 'fade',
-        'event' => 'change',
       ),
     ),
     'islandora_paged_content_sequence_number_field' => array(
@@ -210,53 +208,6 @@ function islandora_paged_content_admin_settings_form_executable_available_messag
  */
 function islandora_paged_content_admin_settings_form_gs_ajax_callback(array $form, array $form_state) {
   return $form['pdf_derivative_settings']['islandora_paged_content_gs'];
-}
-
-/**
- * Gets a message to display if the djatoka is accessible or not.
- *
- * @param string $djatoka_url
- *   The url to an djatoka instance typically
- *   http://localhost:8080/adore-djatoka.
- *
- * @return string
- *   A message in html detailing if the djatoka is accessible.
- */
-function islandora_paged_content_admin_settings_form_djatoka_available_message($djatoka_url) {
-  $file_headers = @get_headers($djatoka_url);
-  $djatoka_available = FALSE;
-  if ($file_headers) {
-    foreach ($file_headers as $file_header) {
-      if (strpos($file_header, '200') !== FALSE) {
-        $djatoka_available = TRUE;
-        break;
-      }
-    }
-  }
-  if ($djatoka_available) {
-    $image = theme_image(array('path' => 'misc/watchdog-ok.png', 'attributes' => array()));
-    $message = t('djatoka url is valid.');
-  }
-  else {
-    $image = theme_image(array('path' => 'misc/watchdog-error.png', 'attributes' => array()));
-    $message = t('Unable to locate djatoka installation at @path', array('@path' => $djatoka_url));
-  }
-  return $image . $message;
-}
-
-/**
- * Ajax callback for the djatoka url textfield.
- *
- * @param array $form
- *   The Drupal form definition.
- * @param array $form_state
- *   The Drupal form state.
- *
- * @return array
- *   The element to render as part the ajax callback.
- */
-function islandora_paged_content_admin_settings_form_djatoka_ajax_callback(array $form, array &$form_state) {
-  return $form['islandora_paged_content_djatoka_url'];
 }
 
 /**

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -26,23 +26,11 @@ function islandora_paged_content_admin_settings_form(array $form, array &$form_s
   $gs = $get_default_value('islandora_paged_content_gs', '/usr/bin/gs');
   $pdfinfo = $get_default_value('islandora_paged_content_pdfinfo', '/usr/bin/pdfinfo');
   $pdftotext = $get_default_value('islandora_paged_content_pdftotext', '/usr/bin/pdftotext');
-  $imageserver_settings = islandora_imageserver_get_settings();
 
   $solr_enabled = module_exists('islandora_solr');
 
   $form = array(
-    'islandora_paged_content_tilesource' => array(
-      '#type' => 'select',
-      '#title' => t('Image Server'),
-      '#description' => t('The image server to use, configure at Admin -> Islandora -> Image server configuration'),
-      '#default_value' => $imageserver_settings['type'],
-      '#disabled' => TRUE,
-      '#options' => array(
-        'none' => t('No image server configured'),
-        'iiif' => t('IIIF image server'),
-        'djatoka' => t('Adore-Djatoka image server'),
-      ),
-    ),
+    'islandora_paged_content_tilesource' => islandora_imageserver_get_type_selectbox(),
     'pdf_derivative_settings' => array(
       '#type' => 'fieldset',
       '#title' => t('PDF Derivative Settings'),

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -874,25 +874,27 @@ function islandora_paged_content_get_page_metadata_from_djatoka($object_id) {
   module_load_include('inc', 'islandora', 'includes/authtokens');
   module_load_include('inc', 'islandora', 'includes/imageserver');
   $settings = islandora_imageserver_get_settings();
-  $datastream_url = url("islandora/object/{$object_id}/datastream/JP2/view", array(
-    'absolute' => TRUE,
-    'query' => array(
-      'token' => islandora_get_object_token($object_id, 'JP2'),
-    ),
-  ));
+  if ($settings['type'] == 'djatoka') {
+    $datastream_url = url("islandora/object/{$object_id}/datastream/JP2/view", array(
+      'absolute' => TRUE,
+      'query' => array(
+        'token' => islandora_get_object_token($object_id, 'JP2'),
+      ),
+    ));
 
-  $djatoka_url = rtrim($settings['url'], '/');
-  $djatoka_url = url($djatoka_url, array(
-    'query' => array(
-      'url_ver' => 'Z39.88-2004',
-      'rft_id' => $datastream_url,
-      'svc_id' => 'info:lanl-repo/svc/getMetadata',
-    ),
-    'external' => TRUE,
-  ));
-  $request = drupal_http_request($djatoka_url);
-  if ($request->code == '200') {
-    return drupal_json_decode($request->data);
+    $djatoka_url = rtrim($settings['url'], '/');
+    $djatoka_url = url($djatoka_url, array(
+      'query' => array(
+        'url_ver' => 'Z39.88-2004',
+        'rft_id' => $datastream_url,
+        'svc_id' => 'info:lanl-repo/svc/getMetadata',
+      ),
+      'external' => TRUE,
+    ));
+    $request = drupal_http_request($djatoka_url);
+    if ($request->code == '200') {
+      return drupal_json_decode($request->data);
+    }
   }
   return FALSE;
 }

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -826,7 +826,7 @@ function islandora_paged_content_get_page_dimensions(AbstractObject $object) {
  * @param AbstractObject $object
  *   The page object.
  *
- * @return array
+ * @return array|bool
  *   An associative array containing the following fields.
  *   - width: The width of the image in pixels.
  *   - height: The width of the image in pixels.
@@ -859,7 +859,7 @@ function islandora_paged_content_get_technical_metadata(AbstractObject $object) 
  * @param string $object_id
  *   The PID of the page to fetch the metadata from.
  *
- * @return array
+ * @return array|bool
  *   An associative array contatining the following string fields:
  *   - identifier: The URL to the resource.
  *   - imagefile: The path to the temp file being served.
@@ -872,6 +872,8 @@ function islandora_paged_content_get_technical_metadata(AbstractObject $object) 
  */
 function islandora_paged_content_get_page_metadata_from_djatoka($object_id) {
   module_load_include('inc', 'islandora', 'includes/authtokens');
+  module_load_include('inc', 'islandora', 'includes/imageserver');
+  $settings = islandora_imageserver_get_settings();
   $datastream_url = url("islandora/object/{$object_id}/datastream/JP2/view", array(
     'absolute' => TRUE,
     'query' => array(
@@ -879,9 +881,8 @@ function islandora_paged_content_get_page_metadata_from_djatoka($object_id) {
     ),
   ));
 
-  $djatoka_url = variable_get('islandora_paged_content_djatoka_url', 'http://localhost:8080/adore-djatoka');
-  $djatoka_url .= (substr($djatoka_url, -1) == '/') ? '' : '/';
-  $djatoka_url = url($djatoka_url . "resolver", array(
+  $djatoka_url = rtrim($settings['url'], '/');
+  $djatoka_url = url($djatoka_url, array(
     'query' => array(
       'url_ver' => 'Z39.88-2004',
       'rft_id' => $datastream_url,


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2469

Related PRs:
* https://github.com/Islandora/islandora/pull/725
* https://github.com/Islandora/islandora_openseadragon/pull/102
* https://github.com/Islandora/islandora_internet_archive_bookreader/pull/136

# What does this Pull Request do?

Removes the configuration of the image server and instead pulls from a new location in core.

# What's new?
Removes the configuration from here, pulls imageserver configuration from core.

# How should this be tested?

Must be tested with https://github.com/Islandora/islandora/pull/725

This module only uses the settings for calculating page dimensions and really only for Djatoka. So you could test that in the IABV.

# Additional Notes:

Example:
* Does this change the interface, add a new feature, or otherwise change behaviours that would require updating documentation? Removed reference to Djatoka URL from README.
* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? Yes if auto-configuration fails until it is corrected.

# Interested parties
@Islandora/7-x-1-x-committers @jonathangreen 
