### PR TITLE
ISLANDORA-2226: Rename the remove_pdf_flag function.

### DIFF
--- a/includes/derivatives.inc
+++ b/includes/derivatives.inc
@@ -122,7 +122,7 @@ function islandora_paged_content_aggregate_pdf_derivative(AbstractObject $object
       )
     );
 
-    $batch['operations'][] = array('islandora_book_batch_remove_pdf_flag', array($object));
+    $batch['operations'][] = array('islandora_paged_content_remove_pdf_flag', array($object));
     batch_set($batch);
   }
 }


### PR DESCRIPTION
## JIRA Ticket
https://jira.lyrasis.org/browse/ISLANDORA-2226

## What does this Pull Request do?
Removes a reference to `islandora_book_batch_remove_pdf_flag`, a function that doesn't exist anymore. It looks like this function was renamed at some point to `islandora_paged_content_remove_pdf_flag`. 

Doing some digging in git history, it looks like `islandora_book_batch_remove_pdf_flag` was removed in https://github.com/Islandora/islandora_book_batch/pull/24 from 2014.

## What's new?
This causes a warning in the batch, however the batch does work. Since this is the last thing that is called. This will eliminate the warning of calling a function that doesn't exist. It will also make sure the flag gets flipped.

## How should this be tested?
Do a book batch with aggregated PDF derivatives enabled, and make sure this warning isn't thrown.

## Interested parties
@whikloj @Islandora/7-x-1-x-committers