### PR TITLE
Adding -dUseCropBox flag to Ghostscript extract tiff from pdf

### DIFF
--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -52,7 +52,7 @@ function islandora_paged_content_admin_settings_form(array $form, array &$form_s
       'islandora_paged_content_usecropbox' => array(
         '#type' => 'checkbox',
         '#title' => t('Use Cropbox'),
-        '#description' => t('Ghostscript will use the CropBox dataset of the uploaded media.'),
+        '#description' => t('Ghostscript will use the CropBox dataset of the uploaded PDF. Sets the page size to the CropBox rather than the MediaBox. Often, but not exclusively, used to aid the positioning of content on the PDF.'),
         '#default_value' => variable_get('islandora_paged_content_usecropbox', FALSE),
       ),
     ),

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -49,6 +49,12 @@ function islandora_paged_content_admin_settings_form(array $form, array &$form_s
           'event' => 'change',
         ),
       ),
+      'islandora_paged_content_usecropbox' => array(
+        '#type' => 'checkbox',
+        '#title' => t('Use Cropbox'),
+        '#description' => t('Ghostscript will use the CropBox dataset of the uploaded media.'),
+        '#default_value' => variable_get('islandora_paged_content_usecropbox', FALSE),
+      ),
     ),
     'pdf_paged_content_ingestion_settings' => array(
       '#type' => 'fieldset',

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -1187,6 +1187,7 @@ function islandora_paged_content_extract_tiff_from_pdf($uri, $offset, $device, $
   }
   $gs = variable_get('islandora_paged_content_gs', '/usr/bin/gs');
   $output_file = drupal_tempnam('temporary://', "page{$offset}.tif");
+  $cropbox = (variable_get('islandora_paged_content_usecropbox', FALSE)) ? '-dUseCropBox' : '';
   // Need to link the file because of UTF-8 encoding.
   $copy = islandora_paged_content_create_clean_link($uri, 'pdfforgs');
   // For all arguments see https://ghostscript.com/doc/current/Devices.htm#TIFF.
@@ -1195,10 +1196,10 @@ function islandora_paged_content_extract_tiff_from_pdf($uri, $offset, $device, $
     // GhostScript versions 9.10 through 9.18 seem affected by a Bug
     // making this devices fail always.
     // @see http://git.ghostscript.com/?p=ghostpdl.git;a=commitdiff;h=f8e77523.
-    $base_command = '!gs_path -q -dNOPAUSE -dBATCH -sDEVICE=!device -sCompression=none -sOutputFile=!output_file -r!resolution -dFirstPage=!offset -dLastPage=!offset !pdf_uri';
+    $base_command = '!gs_path -q -dNOPAUSE !cropbox -dBATCH -sDEVICE=!device -sCompression=none -sOutputFile=!output_file -r!resolution -dFirstPage=!offset -dLastPage=!offset !pdf_uri';
   }
   else {
-    $base_command = '!gs_path -q -dNOPAUSE -dBATCH -sDEVICE=!device -sCompression=lzw -sOutputFile=!output_file -r!resolution -dFirstPage=!offset -dLastPage=!offset !pdf_uri';
+    $base_command = '!gs_path -q -dNOPAUSE !cropbox -dBATCH -sDEVICE=!device -sCompression=lzw -sOutputFile=!output_file -r!resolution -dFirstPage=!offset -dLastPage=!offset !pdf_uri';
   }
   $command = format_string($base_command, array(
     '!gs_path' => escapeshellarg($gs),
@@ -1207,6 +1208,7 @@ function islandora_paged_content_extract_tiff_from_pdf($uri, $offset, $device, $
     '!output_file' => drupal_realpath($output_file),
     '!resolution' => (int) $resolution,
     '!pdf_uri' => escapeshellarg(drupal_realpath($copy)),
+    '!cropbox' => $cropbox,
   ));
   $output = array();
   $ret = 0;


### PR DESCRIPTION
**ISLANDORA-2511**: (https://jira.lyrasis.org/browse/ISLANDORA-2511)

# What does this Pull Request do?

This pull request adds the -dUseCropbox flag to the extract tiff from pdf Ghostscript to use the Cropbox dataset of the PDF.

# How should this be tested?

Steps to test this issue:

* Collect a PDF with differing CropBox and MediaBox data. (Sample data PDF attached to JIRA issue)
* Ensure configuration selection available on /admin/islandora/solution_pack_config/paged_content
* Ingest a PDF book object with “Use Cropbox” not selected
* Ingest a PDF book object with “Use Cropbox” selected
* When the “Use Cropbox” selection is enabled, the derivative is built using the “Cropbox” dataset.

# Interested parties
@Islandora/7-x-1-x-committers
@dannylamb
@bondjimbond 